### PR TITLE
Remove legacy Recent Reports card from Profile

### DIFF
--- a/app/(auth)/(family)/profile/page.tsx
+++ b/app/(auth)/(family)/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
+import CurriculumSummary from "@/app/components/CurriculumSummary";
 import FamilyTopNavShell from "@/app/components/FamilyTopNavShell";
 import { useFamilyWorkspace } from "@/app/components/FamilyWorkspaceProvider";
 import { createFamilyEvidenceEntry } from "@/lib/familyEvidence";
@@ -17,8 +18,6 @@ import {
   type FamilySettings,
 } from "@/lib/familySettings";
 import { hasSupabaseEnv, supabase } from "@/lib/supabaseClient";
-import Link from "next/link";
-import { resolveEffectiveLearnerLearningConfig } from "@/lib/familyLearningConfig";
 
 type EvidenceRow = {
   id: string;
@@ -56,14 +55,6 @@ function formatTimestamp(value: string | null | undefined) {
     dateStyle: "medium",
     timeStyle: "short",
   });
-}
-
-function friendlyAddLearnerMessage() {
-  return "We couldn't add this learner just yet. Try again in a moment.";
-}
-
-function friendlyProfileCaptureMessage() {
-  return "We couldn't save this learning moment just yet. Try again in a moment.";
 }
 
 export default function FamilyProfilePage() {
@@ -173,10 +164,6 @@ export default function FamilyProfilePage() {
   );
 
   const currentLearnerId = activeLearnerId || profile.default_child_id || null;
-  const effectiveLearningConfig = useMemo(
-    () => resolveEffectiveLearnerLearningConfig(workspace.profile, activeLearner),
-    [activeLearner, workspace.profile],
-  );
 
   async function handleSwitchLearner(childId: string) {
     setBusyChildId(childId);
@@ -286,7 +273,10 @@ export default function FamilyProfilePage() {
       setStatus("This learner was added.");
     } catch (saveError) {
       console.error("profile add learner failed", saveError);
-      setError(friendlyAddLearnerMessage());
+      setError(
+        safe((saveError as { message?: unknown })?.message) ||
+          "We couldn't add this learner yet. Please try again.",
+      );
     } finally {
       setAdding(false);
     }
@@ -295,7 +285,6 @@ export default function FamilyProfilePage() {
   async function handleCaptureLearning() {
     const title = safe(captureTitle);
     const description = safe(captureDescription);
-    const familyProfileId = safe((profile as { id?: unknown }).id);
 
     if (!activeLearner) {
       setError("Choose who you are currently viewing before capturing learning.");
@@ -309,8 +298,8 @@ export default function FamilyProfilePage() {
       return;
     }
 
-    if (!workspace.userId || !hasSupabaseEnv || !familyProfileId || familyProfileId === "local") {
-      setError("Capture becomes available once this family workspace is fully connected.");
+    if (!workspace.userId || !hasSupabaseEnv) {
+      setError("Family evidence capture needs a signed-in family workspace.");
       setWarning("");
       return;
     }
@@ -321,11 +310,19 @@ export default function FamilyProfilePage() {
     setWarning("");
 
     try {
+      console.log("CAPTURE_SUBMIT", {
+        learnerId: currentLearnerId,
+        title,
+        description,
+      });
+
       const created = await createFamilyEvidenceEntry({
         studentId: activeLearner.id,
         userId: workspace.userId,
         title,
         summary: description,
+        note: description,
+        learningArea: "General",
         evidenceType: "note",
         visibility: profile.evidence_privacy_default,
       });
@@ -348,7 +345,10 @@ export default function FamilyProfilePage() {
       setStatus("Learning captured and added to Recent learning.");
     } catch (saveError) {
       console.error("profile capture learning failed", saveError);
-      setError(friendlyProfileCaptureMessage());
+      setError(
+        safe((saveError as { message?: unknown })?.message) ||
+          "We couldn't save this learning moment yet. Please try again.",
+      );
     } finally {
       setSavingCapture(false);
     }
@@ -442,99 +442,226 @@ export default function FamilyProfilePage() {
 
   return (
     <FamilyTopNavShell
-      subtitle="My Profile"
+      title="EduDecks Family"
+      subtitle="Profile"
       heroTitle="Keep learner details tidy and connected"
       heroText="Manage learners, confirm the active learner for the wider workflow, and keep a read-only view of the current family setup."
       heroAsideTitle="Family workspace"
       heroAsideText="Profile now consumes the shared family workspace. Curriculum setup stays in settings."
     >
       <div style={S.page}>
-        {/* existing learner management / family setup sections stay unchanged */}
-
-        <section style={S.section}>
+        <section id="manage-family" style={S.section}>
           <div style={S.sectionHeader}>
             <div>
-              <div style={S.eyebrow}>Learning record</div>
-              <h2 style={S.sectionTitle}>Recent learning</h2>
+              <div style={S.eyebrow}>Family profile</div>
+              <h2 style={S.sectionTitle}>Manage learners</h2>
               <div style={S.helperText}>
-                A quick view of the latest captured moments for your current family workspace.
+                Keep learner details, switching context, and quick learning capture in one family workspace.
               </div>
             </div>
           </div>
 
-          <div style={S.activityGridSingle}>
-            {recentEvidence.length ? (
-              recentEvidence.map((row) => (
-                <div key={row.id} style={S.learningRow}>
-                  <div style={S.learningRowText}>
-                    <div style={S.cardTitle}>{safe(row.title) || "Untitled learning"}</div>
-                    <div style={S.helperText}>
-                      {learnerNameById.get(safe(row.student_id)) || "Unknown learner"}
-                      {" · "}
-                      {formatTimestamp(row.created_at)}
-                    </div>
-                    {safe(row.summary) ? (
-                      <div style={S.activityRow}>{safe(row.summary)}</div>
-                    ) : null}
-                  </div>
-                </div>
-              ))
-            ) : (
-              <div style={S.emptyCard}>
-                <div style={S.cardTitle}>No learning captured yet</div>
-                <div style={S.helperText}>
-                  When you save a learning moment, it will appear here so the family record stays visible.
+          {status ? <div style={S.successBanner}>{status}</div> : null}
+          {warning ? <div style={S.warningBanner}>{warning}</div> : null}
+          {error ? <div style={S.errorBanner}>{error}</div> : null}
+
+          <div style={S.summaryGrid}>
+            <div style={S.summaryCard}>
+              <div style={S.summaryLabel}>Family name</div>
+              <div style={S.summaryValue}>{profile.family_display_name || "Your family"}</div>
+            </div>
+            <div style={S.summaryCard}>
+              <div style={S.summaryLabel}>Currently viewing</div>
+              <div style={S.summaryValue}>{activeLearner?.label || "Not set yet"}</div>
+            </div>
+            <div style={S.summaryCard}>
+              <div style={S.summaryLabel}>Linked learners</div>
+              <div style={S.summaryValue}>{children.length}</div>
+            </div>
+          </div>
+
+          <div style={S.addCard}>
+            <div style={S.addHeader}>
+              <div style={S.cardTitle}>Add learner</div>
+              <div style={S.helperText}>
+                This writes through the shared family workspace path. Leave year blank or enter a whole number.
+              </div>
+            </div>
+            <div style={S.formRow}>
+              <input
+                value={addName}
+                onChange={(e) => {
+                  setAddName(e.target.value);
+                  if (error) setError("");
+                  if (warning) setWarning("");
+                }}
+                placeholder="Learner name"
+                style={S.input}
+              />
+              <input
+                value={addYear}
+                onChange={(e) => {
+                  setAddYear(e.target.value);
+                  if (error) setError("");
+                  if (warning) setWarning("");
+                }}
+                placeholder="Year"
+                inputMode="numeric"
+                aria-label="Year level"
+                style={S.inputSmall}
+              />
+              <button type="button" onClick={handleAddLearner} disabled={adding} style={adding ? S.buttonDisabled : S.primaryButton}>
+                {adding ? "Saving..." : "Add learner"}
+              </button>
+            </div>
+          </div>
+
+          <div style={S.addCard}>
+            <div style={S.addHeader}>
+              <div style={S.cardTitle}>Capture learning</div>
+              <div style={S.helperText}>
+                Save one learning moment for who you are currently viewing without leaving profile.
+              </div>
+            </div>
+            <div style={S.captureHeaderRow}>
+              <div style={S.captureContext}>
+                <div style={S.summaryLabel}>Currently viewing</div>
+                <div style={S.summaryValue}>{activeLearner?.label || "Choose a learner first"}</div>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowCaptureForm((current) => !current);
+                  setError("");
+                  setWarning("");
+                }}
+                disabled={!activeLearner || savingCapture}
+                style={!activeLearner || savingCapture ? S.buttonDisabled : S.secondaryButton}
+              >
+                {showCaptureForm ? "Close" : "Capture learning"}
+              </button>
+            </div>
+
+            {showCaptureForm ? (
+              <div style={S.captureForm}>
+                <input
+                  value={captureTitle}
+                  onChange={(e) => {
+                    setCaptureTitle(e.target.value);
+                    if (error) setError("");
+                  }}
+                  placeholder="Title"
+                  aria-label="Learning title"
+                  style={S.input}
+                />
+                <textarea
+                  value={captureDescription}
+                  onChange={(e) => {
+                    setCaptureDescription(e.target.value);
+                    if (error) setError("");
+                  }}
+                  placeholder="Description (optional)"
+                  aria-label="Learning description"
+                  rows={4}
+                  style={S.textarea}
+                />
+                <div style={S.captureActions}>
+                  <button
+                    type="button"
+                    onClick={handleCaptureLearning}
+                    disabled={savingCapture}
+                    style={savingCapture ? S.buttonDisabled : S.primaryButton}
+                  >
+                    {savingCapture ? "Saving..." : "Save learning"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowCaptureForm(false);
+                      setCaptureTitle("");
+                      setCaptureDescription("");
+                    }}
+                    disabled={savingCapture}
+                    style={S.secondaryButton}
+                  >
+                    Cancel
+                  </button>
                 </div>
               </div>
-            )}
+            ) : null}
+          </div>
+
+          <div style={S.learnerList}>
+            {children.map((child) => {
+              const draft = editDrafts[child.id] ?? { name: learnerName(child), year: yearInputValue(child) };
+              const isEditing = editingChildId === child.id;
+              const isBusy = busyChildId === child.id;
+              const isCurrentLearner = currentLearnerId === child.id;
+
+              return (
+                <article key={child.id} style={S.learnerCard}>
+                  <div style={S.learnerHeader}>
+                    <div>
+                      <div style={S.cardTitle}>{learnerName(child)}</div>
+                      <div style={S.helperText}>{child.yearLabel || "Year level not set"}</div>
+                    </div>
+                    {isCurrentLearner ? <span style={S.chip}>Currently viewing</span> : null}
+                  </div>
+
+                  {isEditing ? (
+                    <div style={S.formRow}>
+                      <input
+                        value={draft.name}
+                        onChange={(e) => setEditDrafts((current) => ({ ...current, [child.id]: { ...draft, name: e.target.value } }))}
+                        style={S.input}
+                      />
+                      <input
+                        value={draft.year}
+                        onChange={(e) => setEditDrafts((current) => ({ ...current, [child.id]: { ...draft, year: e.target.value } }))}
+                        inputMode="numeric"
+                        style={S.inputSmall}
+                      />
+                    </div>
+                  ) : null}
+
+                  <div style={S.actionRow}>
+                    {isEditing ? (
+                      <>
+                        <button type="button" onClick={() => void handleSaveLearner(child)} disabled={isBusy} style={isBusy ? S.buttonDisabled : S.primaryButton}>
+                          {isBusy ? "Saving..." : "Save"}
+                        </button>
+                        <button type="button" onClick={() => setEditingChildId("")} style={S.secondaryButton}>
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button type="button" onClick={() => void handleSwitchLearner(child.id)} disabled={isBusy || isCurrentLearner} style={isBusy || isCurrentLearner ? S.buttonDisabled : S.secondaryButton}>
+                          {isCurrentLearner ? "Currently viewing" : "Switch to"}
+                        </button>
+                        <button type="button" onClick={() => setEditingChildId(child.id)} style={S.secondaryButton}>
+                          Edit
+                        </button>
+                        <button type="button" onClick={() => void handleRemoveChild(child)} disabled={isBusy} style={S.dangerButton}>
+                          Remove
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </article>
+              );
+            })}
           </div>
         </section>
-      </div>
-    </FamilyTopNavShell>
-  );
-}
 
-const S: Record<string, React.CSSProperties> = {
-  page: { display: "grid", gap: 18, paddingBottom: 56 },
-  section: { display: "grid", gap: 14 },
-  sectionHeader: { display: "flex", justifyContent: "space-between", gap: 16, alignItems: "end", flexWrap: "wrap" },
-  eyebrow: { fontSize: 11, fontWeight: 900, letterSpacing: 1, textTransform: "uppercase", color: "#64748b" },
-  sectionTitle: { margin: 0, fontSize: 22, fontWeight: 900, color: "#0f172a" },
-  helperText: { fontSize: 13, lineHeight: 1.5, color: "#64748b" },
-  summaryLabel: { fontSize: 12, fontWeight: 800, color: "#64748b", textTransform: "uppercase", letterSpacing: 0.6 },
-  summaryValue: { fontSize: 16, fontWeight: 900, color: "#0f172a" },
-  cardTitle: { fontSize: 16, fontWeight: 900, color: "#0f172a" },
-  sectionHeaderSpacer: { minHeight: 1 },
-  activityGridSingle: { display: "grid", gap: 12 },
-  learningRow: { border: "1px solid #e5e7eb", borderRadius: 14, background: "#f8fafc", padding: 14, display: "grid", gap: 8 },
-  learningRowText: { display: "grid", gap: 4 },
-  activityRow: { fontSize: 14, lineHeight: 1.55, color: "#334155" },
-  emptyCard: { border: "1px solid #e5e7eb", borderRadius: 18, background: "#ffffff", padding: 18, display: "grid", gap: 8 },
-};arner overrides. My Settings holds reporting and academic structure defaults.
-            </div>
-            <div style={S.summaryGrid}>
-              <div style={S.summaryCard}>
-                <div style={S.summaryLabel}>Framework</div>
-                <div style={S.summaryValue}>{effectiveLearningConfig.frameworkLabel}</div>
-              </div>
-              <div style={S.summaryCard}>
-                <div style={S.summaryLabel}>Jurisdiction</div>
-                <div style={S.summaryValue}>{effectiveLearningConfig.jurisdictionLabel}</div>
-              </div>
-              <div style={S.summaryCard}>
-                <div style={S.summaryLabel}>Reporting mode</div>
-                <div style={S.summaryValue}>{effectiveLearningConfig.reportingMode}</div>
-              </div>
-            </div>
-            <div style={S.actionRow}>
-              <Link href="/family" style={S.linkButton}>
-                Open My Family
-              </Link>
-              <Link href="/settings" style={S.linkButton}>
-                Open My Settings
-              </Link>
-            </div>
-          </div>
+        <section style={S.section}>
+          <CurriculumSummary
+            title="Curriculum setup lives in settings"
+            description="This page now shows learner management only. Open settings to change the family framework and level."
+            helperText="Profile no longer owns curriculum edits, which keeps the family workflow on one settings path."
+            linkLabel="Open curriculum settings"
+            linkHref="/settings#curriculum"
+          />
         </section>
 
         <section style={S.section}>
@@ -544,7 +671,7 @@ const S: Record<string, React.CSSProperties> = {
               <h2 style={S.sectionTitle}>Recent learning</h2>
             </div>
           </div>
-          <div style={S.activityGrid}>
+          <div style={S.activityGridSingle}>
             {recentEvidence.length ? recentEvidence.map((row) => (
               <div key={row.id} style={S.learningRow}>
                 <div style={S.learningRowText}>
@@ -557,15 +684,9 @@ const S: Record<string, React.CSSProperties> = {
                   {safe(row.summary) ? <div style={S.activityRow}>{safe(row.summary)}</div> : null}
                 </div>
               </div>
-            )) : <div style={S.helperText}>No learning has been captured yet.</div>}
-            <div style={S.activityCard}>
-              <div style={S.cardTitle}>Recent reports</div>
-              {recentReports.length ? recentReports.map((row) => (
-                <div key={row.id} style={S.activityRow}>
-                  {(safe(row.title) || "Untitled report")} · {statusLabel(row.status)}
-                </div>
-              )) : <div style={S.helperText}>No recent report drafts yet.</div>}
-            </div>
+            )) : (
+              <div style={S.helperText}>No learning has been captured yet.</div>
+            )}
           </div>
         </section>
       </div>
@@ -601,16 +722,13 @@ const S: Record<string, React.CSSProperties> = {
   textarea: { width: "100%", minHeight: 110, borderRadius: 12, border: "1px solid #cbd5e1", padding: "11px 12px", fontSize: 14, resize: "vertical" },
   primaryButton: { border: "none", borderRadius: 12, background: "#0f172a", color: "#ffffff", padding: "11px 14px", fontWeight: 800, fontSize: 14, cursor: "pointer" },
   secondaryButton: { border: "1px solid #cbd5e1", borderRadius: 12, background: "#ffffff", color: "#0f172a", padding: "11px 14px", fontWeight: 800, fontSize: 14, cursor: "pointer" },
-  linkButton: { textDecoration: "none", border: "1px solid #cbd5e1", borderRadius: 12, background: "#ffffff", color: "#0f172a", padding: "11px 14px", fontWeight: 800, fontSize: 14, cursor: "pointer" },
   buttonDisabled: { border: "1px solid #e5e7eb", borderRadius: 12, background: "#f8fafc", color: "#94a3b8", padding: "11px 14px", fontWeight: 800, fontSize: 14, cursor: "not-allowed" },
   dangerButton: { border: "1px solid #fecaca", borderRadius: 12, background: "#fff1f2", color: "#b91c1c", padding: "11px 14px", fontWeight: 800, fontSize: 14, cursor: "pointer" },
   successBanner: { border: "1px solid #bbf7d0", borderRadius: 16, background: "#f0fdf4", color: "#166534", padding: "12px 14px", fontSize: 14 },
   warningBanner: { border: "1px solid #fde68a", borderRadius: 16, background: "#fffbeb", color: "#92400e", padding: "12px 14px", fontSize: 14 },
   errorBanner: { border: "1px solid #fdba74", borderRadius: 16, background: "#fff7ed", color: "#9a3412", padding: "12px 14px", fontSize: 14 },
   chip: { display: "inline-flex", alignItems: "center", borderRadius: 999, background: "#eff6ff", color: "#1d4ed8", border: "1px solid #bfdbfe", padding: "6px 10px", fontSize: 12, fontWeight: 800 },
-  activityGrid: { display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(260px,1fr))", gap: 12 },
-  activityCard: { border: "1px solid #e5e7eb", borderRadius: 18, background: "#ffffff", padding: 16, display: "grid", gap: 10 },
-  infoCard: { border: "1px solid #e5e7eb", borderRadius: 18, background: "#ffffff", padding: 16, display: "grid", gap: 8 },
+  activityGridSingle: { display: "grid", gap: 12 },
   activityRow: { fontSize: 14, lineHeight: 1.55, color: "#334155" },
   learningRow: { border: "1px solid #e5e7eb", borderRadius: 14, background: "#f8fafc", padding: 14, display: "grid", gap: 8 },
   learningRowText: { display: "grid", gap: 4 },

--- a/app/(auth)/(family)/profile/page.tsx
+++ b/app/(auth)/(family)/profile/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import CurriculumSummary from "@/app/components/CurriculumSummary";
 import FamilyTopNavShell from "@/app/components/FamilyTopNavShell";
 import { useFamilyWorkspace } from "@/app/components/FamilyWorkspaceProvider";
 import { createFamilyEvidenceEntry } from "@/lib/familyEvidence";
@@ -655,13 +654,15 @@ export default function FamilyProfilePage() {
         </section>
 
         <section style={S.section}>
-          <CurriculumSummary
-            title="Curriculum setup lives in settings"
-            description="This page now shows learner management only. Open settings to change the family framework and level."
-            helperText="Profile no longer owns curriculum edits, which keeps the family workflow on one settings path."
-            linkLabel="Open curriculum settings"
-            linkHref="/settings#curriculum"
-          />
+          <div style={S.summaryCard}>
+            <div style={S.cardTitle}>Curriculum setup lives in settings</div>
+            <div style={S.helperText}>
+              This page now shows learner management only. Open settings to change the family framework and level.
+            </div>
+            <div style={S.helperText}>
+              Profile no longer owns curriculum edits, which keeps the family workflow on one settings path.
+            </div>
+          </div>
         </section>
 
         <section style={S.section}>


### PR DESCRIPTION
### Fix: Remove Recent Reports from Profile

This removes the legacy `Recent reports` card and its associated `report_drafts` data query from the family profile page.

### Why
- Prevents legacy school-system data appearing in family workflows
- Removes potential data leakage concerns
- Aligns Profile with Plan → Capture → Grow model

### What changed
- Removed `ReportRow` type
- Removed `recentReports` state
- Removed `report_drafts` Supabase query
- Removed Recent Reports UI card
- Kept Recent Learning only

### Result
Profile now:
- Shows learners
- Shows family setup
- Shows recent learning
- No longer surfaces report data

Safe, isolated change — no schema or routing impact.