### PR TITLE
[Superseded by #10] Refine Community category & thread pages for safe read-first behavior

### DIFF
--- a/app/(auth)/community/[categorySlug]/[threadId]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/[threadId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import FamilyTopNavShell from "@/app/components/FamilyTopNavShell";
@@ -57,62 +57,6 @@ function statusBadge(status: ForumThreadStatus): React.CSSProperties {
   return { border: "1px solid #bbf7d0", background: "#f0fdf4", color: "#166534" };
 }
 
-function fallbackThread(
-  categorySlug: string,
-  id: string,
-): { category: ForumCategory; thread: ThreadView; replies: ReplyView[] } {
-  return {
-    category: {
-      id: categorySlug || "general-discussion",
-      slug: categorySlug || "general-discussion",
-      name: categorySlug === "help-shape-edudecks" ? "Help Shape MyLearna" : "General Discussion",
-      description: "A calm place for homeschool families to talk through everyday learning and family life.",
-      created_at: new Date().toISOString(),
-    },
-    thread: {
-      id,
-      category_id: categorySlug || "general-discussion",
-      categorySlug: categorySlug || "general-discussion",
-      user_id: "demo-user",
-      title: "Welcome to the MyLearna community",
-      body:
-        "This is a preview thread so the community space feels alive from first click.\n\nFamilies can share ideas, resources, routines, questions, and encouragement here in a calm, structured format.",
-      excerpt: "This is a preview thread so the community space feels alive from first click.",
-      is_pinned: true,
-      status: "under_review",
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      authorLabel: "MyLearna Community",
-      replyCount: 2,
-      latestActivityAt: new Date().toISOString(),
-      supportCount: 0,
-      viewerSupports: false,
-    },
-    replies: [
-      {
-        id: "reply-1",
-        thread_id: id,
-        user_id: "demo-user-2",
-        body: "I love the idea of having a forum that feels calm and practical rather than noisy.",
-        excerpt: "I love the idea of having a forum that feels calm and practical rather than noisy.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        authorLabel: "Homeschool parent",
-      },
-      {
-        id: "reply-2",
-        thread_id: id,
-        user_id: "demo-user-3",
-        body: "A category for resources and another for new homeschoolers would be especially useful.",
-        excerpt: "A category for resources and another for new homeschoolers would be especially useful.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        authorLabel: "MyLearna family",
-      },
-    ],
-  };
-}
-
 export default function CommunityThreadPage() {
   const params = useParams<{ categorySlug: string; threadId: string }>();
   const categorySlug = String(params?.categorySlug ?? "");
@@ -127,8 +71,7 @@ export default function CommunityThreadPage() {
   const [replying, setReplying] = useState(false);
   const [supporting, setSupporting] = useState(false);
   const [message, setMessage] = useState("");
-
-  const previewMode = useMemo(() => !viewerId || viewerId === "demo-user", [viewerId]);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -139,18 +82,9 @@ export default function CommunityThreadPage() {
 
         if (!mounted) return;
 
-        setViewerId(userId ?? "demo-user");
+        setViewerId(userId);
 
-        if (!userId) {
-          const preview = fallbackThread(categorySlug, threadId);
-          setThread(preview.thread);
-          setReplies(preview.replies);
-          setCategory(preview.category);
-          setLoading(false);
-          return;
-        }
-
-        const data = await loadThreadPageData(threadId, userId);
+        const data = await loadThreadPageData(threadId, userId ?? null);
 
         if (!mounted) return;
 
@@ -158,20 +92,19 @@ export default function CommunityThreadPage() {
           setThread(data.thread as ThreadView);
           setReplies((data.replies as ReplyView[]) ?? []);
           setCategory(data.category);
+          setLoadError(false);
         } else {
-          const preview = fallbackThread(categorySlug, threadId);
-          setThread(preview.thread);
-          setReplies(preview.replies);
-          setCategory(preview.category);
+          setThread(null);
+          setReplies([]);
+          setCategory(data.category);
         }
       } catch (error) {
         console.error("Community thread load failed", error);
         if (!mounted) return;
-        const preview = fallbackThread(categorySlug, threadId);
-        setViewerId("demo-user");
-        setThread(preview.thread);
-        setReplies(preview.replies);
-        setCategory(preview.category);
+        setThread(null);
+        setReplies([]);
+        setCategory(null);
+        setLoadError(true);
       } finally {
         if (mounted) setLoading(false);
       }
@@ -191,33 +124,8 @@ export default function CommunityThreadPage() {
       return;
     }
 
-    if (previewMode) {
-      const nextTimestamp = new Date().toISOString();
-      setReplies((current) => [
-        ...current,
-        {
-          id: `preview-reply-${Date.now()}`,
-          thread_id: thread.id,
-          user_id: "demo-user",
-          body: replyBody,
-          excerpt: replyBody,
-          created_at: nextTimestamp,
-          updated_at: nextTimestamp,
-          authorLabel: "You",
-        },
-      ]);
-      setThread((current) =>
-        current
-          ? {
-              ...current,
-              replyCount: current.replyCount + 1,
-              latestActivityAt: nextTimestamp,
-              updated_at: nextTimestamp,
-            }
-          : current,
-      );
-      setReplyBody("");
-      setMessage("Preview reply added. Live posting will work once community sign-in is connected.");
+    if (!viewerId) {
+      setMessage("Please sign in to reply thoughtfully.");
       return;
     }
 
@@ -258,11 +166,8 @@ export default function CommunityThreadPage() {
   async function handleSupport() {
     if (!thread || thread.viewerSupports) return;
 
-    if (previewMode) {
-      setThread((current) =>
-        current ? { ...current, supportCount: current.supportCount + 1, viewerSupports: true } : current,
-      );
-      setMessage("Preview support recorded.");
+    if (!viewerId) {
+      setMessage("Please sign in to support this idea.");
       return;
     }
 
@@ -329,7 +234,14 @@ export default function CommunityThreadPage() {
             gap: 10,
           }}
         >
-          <div style={{ fontSize: 20, fontWeight: 900, color: "#0f172a" }}>Thread not found</div>
+          <div style={{ fontSize: 20, fontWeight: 900, color: "#0f172a" }}>
+            {loadError ? "We couldn’t open this conversation just now." : "This conversation could not be found."}
+          </div>
+          <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569" }}>
+            {loadError
+              ? "Try again in a moment. You can also return to the community area."
+              : "It may have been removed or is not available right now."}
+          </div>
           <Link href="/community" style={{ color: "#2563eb", fontWeight: 800, textDecoration: "none" }}>
             Back to Community
           </Link>
@@ -462,29 +374,48 @@ export default function CommunityThreadPage() {
           </section>
 
           <section style={{ display: "grid", gap: 14, marginBottom: 18 }}>
-            {replies.map((reply) => (
+            {replies.length === 0 ? (
               <article
-                key={reply.id}
                 style={{
                   border: "1px solid #e5e7eb",
                   background: "#ffffff",
                   borderRadius: 18,
-                  padding: 16,
-                  boxShadow: "0 10px 30px rgba(15,23,42,0.04)",
+                  padding: 20,
                   display: "grid",
-                  gap: 10,
+                  gap: 8,
                 }}
               >
-                <div style={{ fontSize: 12, color: "#64748b", fontWeight: 700 }}>
-                  {reply.authorLabel} - {relativeTime(reply.created_at)}
-                </div>
-                <div style={{ fontSize: 14, lineHeight: 1.7, color: "#334155", whiteSpace: "pre-wrap" }}>
-                  {reply.body}
+                <div style={{ fontSize: 18, fontWeight: 900, color: "#0f172a" }}>No replies yet</div>
+                <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569" }}>
+                  When someone responds, the conversation will appear here.
                 </div>
               </article>
-            ))}
+            ) : (
+              replies.map((reply) => (
+                <article
+                  key={reply.id}
+                  style={{
+                    border: "1px solid #e5e7eb",
+                    background: "#ffffff",
+                    borderRadius: 18,
+                    padding: 16,
+                    boxShadow: "0 10px 30px rgba(15,23,42,0.04)",
+                    display: "grid",
+                    gap: 10,
+                  }}
+                >
+                  <div style={{ fontSize: 12, color: "#64748b", fontWeight: 700 }}>
+                    {reply.authorLabel} - {relativeTime(reply.created_at)}
+                  </div>
+                  <div style={{ fontSize: 14, lineHeight: 1.7, color: "#334155", whiteSpace: "pre-wrap" }}>
+                    {reply.body}
+                  </div>
+                </article>
+              ))
+            )}
           </section>
 
+          {viewerId ? (
           <section
             style={{
               border: "1px solid #e5e7eb",
@@ -541,6 +472,24 @@ export default function CommunityThreadPage() {
               </button>
             </div>
           </section>
+          ) : (
+            <section
+              style={{
+                border: "1px solid #e5e7eb",
+                background: "#ffffff",
+                borderRadius: 22,
+                padding: 20,
+                boxShadow: "0 10px 30px rgba(15,23,42,0.04)",
+                display: "grid",
+                gap: 8,
+              }}
+            >
+              <div style={{ fontSize: 18, fontWeight: 900, color: "#0f172a" }}>Reply thoughtfully</div>
+              <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569" }}>
+                Sign in to add a reply to this conversation.
+              </div>
+            </section>
+          )}
         </>
       )}
     </FamilyTopNavShell>

--- a/app/(auth)/community/[categorySlug]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/page.tsx
@@ -13,38 +13,6 @@ import {
   type ForumThreadSummary,
 } from "@/lib/communityForum";
 
-type FallbackThread = ForumThreadSummary & {
-  authorLabel?: string;
-  latestActivityText?: string;
-  viewerSupports?: boolean;
-};
-
-function makeFallbackThread(
-  thread: Omit<
-    FallbackThread,
-    "user_id" | "authorLabel" | "latestActivityText" | "viewerSupports" | "excerpt" | "categorySlug" | "latestActivityAt"
-  > & {
-    user_id?: string;
-    authorLabel?: string;
-    latestActivityText?: string;
-    viewerSupports?: boolean;
-    excerpt?: string;
-    categorySlug?: string;
-    latestActivityAt?: string;
-  },
-): FallbackThread {
-  return {
-    ...thread,
-    user_id: thread.user_id ?? "demo-user",
-    excerpt: thread.excerpt ?? thread.body,
-    categorySlug: thread.categorySlug ?? String(thread.category_id),
-    authorLabel: thread.authorLabel ?? "MyLearna Community",
-    latestActivityText: thread.latestActivityText ?? "No replies yet",
-    latestActivityAt: thread.latestActivityAt ?? thread.updated_at,
-    viewerSupports: thread.viewerSupports ?? false,
-  };
-}
-
 const CATEGORY_FALLBACKS: Record<
   string,
   {
@@ -52,7 +20,6 @@ const CATEGORY_FALLBACKS: Record<
     description: string;
     emptyTitle: string;
     emptyText: string;
-    starterThreads: FallbackThread[];
   }
 > = {
   "general-discussion": {
@@ -62,22 +29,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Be the first to start this conversation",
     emptyText:
       "This is the place for everyday homeschool conversation, practical questions, and warm encouragement.",
-    starterThreads: [
-      makeFallbackThread({
-        id: "sample-general-1",
-        category_id: "general-discussion",
-        categorySlug: "general-discussion",
-        title: "What does a calm homeschool morning look like for your family?",
-        body: "Share one thing that helps the day begin well.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        replyCount: 0,
-        is_pinned: true,
-        status: "under_review",
-        supportCount: 0,
-        authorLabel: "MyLearna Community",
-      }),
-    ],
   },
   "planning-ideas": {
     name: "Planning Ideas",
@@ -86,22 +37,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Start the first planning discussion",
     emptyText:
       "Ask about weekly planning, year levels, and how other families organise their learning.",
-    starterThreads: [
-      makeFallbackThread({
-        id: "sample-plan-1",
-        category_id: "planning-ideas",
-        categorySlug: "planning-ideas",
-        title: "How do you plan for multiple children at different ages?",
-        body: "Share routines, tools, or simple systems that actually help.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        replyCount: 0,
-        is_pinned: true,
-        status: "under_review",
-        supportCount: 0,
-        authorLabel: "MyLearna Community",
-      }),
-    ],
   },
   "homeschool-resources": {
     name: "Homeschool Resources",
@@ -110,7 +45,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Be the first to share a helpful resource",
     emptyText:
       "Useful recommendations, printables, tools, and curriculum ideas can begin here.",
-    starterThreads: [],
   },
   "classical-education": {
     name: "Classical Education",
@@ -119,7 +53,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Start the first classical education discussion",
     emptyText:
       "A calm place to discuss classical approaches, great books, memory work, and structured rhythms.",
-    starterThreads: [],
   },
   "getting-started": {
     name: "Getting Started",
@@ -128,22 +61,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Ask the first beginner question",
     emptyText:
       "This category is for new families who need a simple, safe starting point.",
-    starterThreads: [
-      makeFallbackThread({
-        id: "sample-new-1",
-        category_id: "getting-started",
-        categorySlug: "getting-started",
-        title: "What should I focus on first in my first month of homeschooling?",
-        body: "Share simple advice for families just getting started.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        replyCount: 0,
-        is_pinned: true,
-        status: "under_review",
-        supportCount: 0,
-        authorLabel: "MyLearna Community",
-      }),
-    ],
   },
   "christian-homeschooling": {
     name: "Christian Homeschooling",
@@ -152,22 +69,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Start the first faith discussion",
     emptyText:
       "A gentle space for Christian homeschool families to share faith-based ideas and encouragement.",
-    starterThreads: [
-      makeFallbackThread({
-        id: "sample-faith-1",
-        category_id: "christian-homeschooling",
-        categorySlug: "christian-homeschooling",
-        title: "What has helped your family build a simple Bible routine?",
-        body: "Share practical ideas for keeping Christ central in the week.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        replyCount: 0,
-        is_pinned: true,
-        status: "under_review",
-        supportCount: 0,
-        authorLabel: "MyLearna Community",
-      }),
-    ],
   },
   "help-shape-edudecks": {
     name: "Help Shape MyLearna",
@@ -176,22 +77,6 @@ const CATEGORY_FALLBACKS: Record<
     emptyTitle: "Share the first MyLearna idea",
     emptyText:
       "Tell us what would help your family most and why it matters.",
-    starterThreads: [
-      makeFallbackThread({
-        id: "sample-feature-1",
-        category_id: "help-shape-edudecks",
-        categorySlug: "help-shape-edudecks",
-        title: "A better way to compare multiple children's weekly plans",
-        body: "This could help families with more than one learner see the whole week at a glance.",
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        replyCount: 0,
-        is_pinned: true,
-        status: "under_review",
-        supportCount: 3,
-        authorLabel: "MyLearna Community",
-      }),
-    ],
   },
 };
 
@@ -204,7 +89,6 @@ function getFallbackCategory(slug: string) {
       emptyTitle: "Start the first discussion",
       emptyText:
         "This category is ready for the first thoughtful conversation.",
-      starterThreads: [],
     }
   );
 }
@@ -216,6 +100,7 @@ export default function CommunityCategoryPage() {
   const [category, setCategory] = useState<ForumCategory | null>(null);
   const [threads, setThreads] = useState<ForumThreadSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   const fallback = useMemo(() => getFallbackCategory(slug), [slug]);
   const composeHref = `/community/new?category=${encodeURIComponent(slug)}`;
@@ -226,39 +111,21 @@ export default function CommunityCategoryPage() {
     async function load() {
       try {
         const userId = await requireCommunityUserId();
-        const data = await loadCategoryPageData(slug, userId ?? "demo-user");
+        const data = await loadCategoryPageData(slug, userId ?? null);
 
         if (!mounted) return;
 
-        setCategory(
-          data.category ||
-            ({
-              id: slug,
-              slug,
-              name: fallback.name,
-              description: fallback.description,
-              created_at: new Date().toISOString(),
-            } as ForumCategory),
-        );
-
-        if (data.threads?.length) {
-          setThreads(data.threads);
-        } else {
-          setThreads(fallback.starterThreads);
-        }
+        setCategory(data.category || null);
+        setThreads(data.threads || []);
+        setLoadError(false);
       } catch (error) {
         console.error("Community category load failed", error);
 
         if (!mounted) return;
 
-        setCategory({
-          id: slug,
-          slug,
-          name: fallback.name,
-          description: fallback.description,
-          created_at: new Date().toISOString(),
-        } as ForumCategory);
-        setThreads(fallback.starterThreads);
+        setCategory(null);
+        setThreads([]);
+        setLoadError(true);
       } finally {
         if (mounted) setLoading(false);
       }
@@ -269,26 +136,49 @@ export default function CommunityCategoryPage() {
     return () => {
       mounted = false;
     };
-  }, [fallback.description, fallback.name, fallback.starterThreads, slug]);
+  }, [slug]);
 
-  const resolvedCategory = category || ({
-    id: slug,
-    slug,
-    name: fallback.name,
-    description: fallback.description,
-    created_at: new Date().toISOString(),
-  } as ForumCategory);
+  const resolvedCategory = category;
   const isFeatureCategory = isFeatureSuggestionCategory(resolvedCategory);
 
   return (
     <FamilyTopNavShell
       title="MyLearna Family"
       subtitle="Community"
-      heroTitle={resolvedCategory.name}
-      heroText={resolvedCategory.description}
+      heroTitle={resolvedCategory?.name || fallback.name}
+      heroText={resolvedCategory?.description || fallback.description}
       hideHeroAside={true}
       workflowHelperText="Community categories stay calm and readable: a clear title, recent discussions, and one simple path to start a new thread."
     >
+      {!resolvedCategory ? (
+        <section
+          style={{
+            border: "1px solid #e5e7eb",
+            background: "#ffffff",
+            borderRadius: 20,
+            padding: 24,
+            display: "grid",
+            gap: 10,
+          }}
+        >
+          <div style={{ fontSize: 20, fontWeight: 900, color: "#0f172a" }}>
+            {loadError ? "We couldn’t open this community area just now." : "This community area could not be found."}
+          </div>
+          <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569" }}>
+            {loadError
+              ? "Try again in a moment. You can also return to Community and choose another area."
+              : "It may have been moved or is not available yet."}
+          </div>
+          <div>
+            <Link
+              href="/community"
+              style={{ color: "#2563eb", fontWeight: 800, textDecoration: "none", fontSize: 14 }}
+            >
+              Back to Community
+            </Link>
+          </div>
+        </section>
+      ) : (
       <section
         style={{
           border: "1px solid #e5e7eb",
@@ -316,10 +206,10 @@ export default function CommunityCategoryPage() {
               Category
             </div>
             <div style={{ fontSize: 28, lineHeight: 1.15, fontWeight: 900, color: "#0f172a" }}>
-              {resolvedCategory.name}
+              {resolvedCategory?.name}
             </div>
             <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569", marginTop: 8, maxWidth: 760 }}>
-              {resolvedCategory.description}
+              {resolvedCategory?.description}
             </div>
           </div>
 
@@ -357,8 +247,9 @@ export default function CommunityCategoryPage() {
           </div>
         </div>
       </section>
+      )}
 
-      {loading ? (
+      {resolvedCategory && loading ? (
         <section
           style={{
             border: "1px solid #e5e7eb",
@@ -371,7 +262,7 @@ export default function CommunityCategoryPage() {
         >
           Loading threads...
         </section>
-      ) : threads.length === 0 ? (
+      ) : resolvedCategory && threads.length === 0 ? (
         <section
           style={{
             border: "1px solid #e5e7eb",
@@ -407,13 +298,13 @@ export default function CommunityCategoryPage() {
             </Link>
           </div>
         </section>
-      ) : (
+      ) : resolvedCategory ? (
         <section style={{ display: "grid", gap: 14 }}>
           {threads.map((thread) => (
             <ForumThreadRow key={thread.id} thread={thread} />
           ))}
         </section>
-      )}
+      ) : null}
     </FamilyTopNavShell>
   );
 }


### PR DESCRIPTION
### Motivation
- Make category and thread routes read-first and honest by removing seeded/demo fallback conversations and preview writes so users see only real data or calm empty/error states.
- Preserve clear navigation and the existing compose flow while preventing any fake posting/support interactions in the UI.

### Description
- Updated `app/(auth)/community/[categorySlug]/page.tsx` to remove seeded starter threads, add `loadError` handling, show calm not-found/load-failure UI, and render threads only when real data is returned, preserving the `Start a discussion` route to `/community/new`.
- Updated `app/(auth)/community/[categorySlug]/[threadId]/page.tsx` to remove preview/demo thread and reply injection, add `loadError` handling and a clear "No replies yet" empty state, and make reply/support affordances conditional on a real signed-in viewer ID.
- Stopped passing a demo viewer ID into loaders (`requireCommunityUserId` consumption now passes `null` when absent) and removed helper fallback functions/preview paths used to fabricate content.
- No repository/helper or schema files changed, and navigation/global shell was not altered.

### Testing
- Attempted build with `npm.cmd run build` which failed in this environment with `/bin/bash: npm.cmd: command not found`.
- Attempted build with `npm run build` which failed with `sh: 1: next: not found` indicating the Next.js binary is not available in this container, so a full compile verification could not be performed.
- Ran `npm install` in the workspace (completed with warnings about `http-proxy` and environment), but full build/runtime validation remains blocked by missing Next runtime.
- Verified changes via code inspection and local file diffs and committed the update (`Refine community category and thread read states`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe7324b508328b162d2f2e5b887ca)