### PR TITLE
Make primary nav always visible and clarify My Day start-path copy

### DIFF
--- a/app/components/FamilyTopNavShell.tsx
+++ b/app/components/FamilyTopNavShell.tsx
@@ -259,7 +259,7 @@ export default function FamilyTopNavShell({
               <BrandHomeLink href="/my-day" />
             </div>
 
-            <nav className="hidden min-w-0 items-center gap-1.5 rounded-full border border-slate-200/80 bg-slate-50/80 p-1 lg:flex">
+            <nav className="flex min-w-0 items-center gap-1.5 overflow-x-auto rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
               {PRIMARY_NAV.map((item) => {
                 const active = normalizedPath === item.href;
                 return (

--- a/app/components/day/MyDayOverviewComponents.tsx
+++ b/app/components/day/MyDayOverviewComponents.tsx
@@ -466,31 +466,31 @@ export function MyDayQuickLinks() {
     {
       href: "/my-calendar",
       label: "My Calendar",
-      note: "Set the reusable weekly rhythm that the rest of the workflow lands into.",
+      note: "Start here to set the weekly rhythm that My Programs and My Plan use.",
     },
     {
       href: "/my-programs",
       label: "My Programs",
-      note: "Build the longer sequence before it drops into the live week.",
+      note: "Build the longer sequence, then place it into that calendar rhythm.",
     },
     {
       href: "/my-plan",
       label: "My Plan",
-      note: "Edit the live week, add blocks, and keep the next few days clear.",
+      note: "Edit the live week so today has one clear next block.",
     },
     {
       href: "/capture",
       label: "Capture",
-      note: "Run the day and save evidence while the learning is still fresh.",
+      note: "Run the day and capture evidence while learning is still fresh.",
     },
   ];
 
   return (
     <section className="grid gap-4">
       <div className="grid gap-1.5">
-        <div className={LABEL}>Quick links</div>
+        <div className={LABEL}>Where to start</div>
         <h2 className="text-[18px] font-bold tracking-[-0.02em] text-slate-950">
-          Know where each layer lives
+          Follow the core workflow in order
         </h2>
       </div>
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -507,7 +507,8 @@ export function MyDayQuickLinks() {
       </div>
       <p className="text-[13px] leading-6 text-slate-500">
         Outputs in the top navigation groups My Curriculum, My Portfolio, My Reports, and My
-        Progress. Community stays separate in the header so planning and discussion do not compete.
+        Progress for reflection. Community stays separate in the header so planning and discussion
+        do not compete.
       </p>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Ensure the top navigation consistently exposes the primary MyLearna workflow and that the My Day entry clearly guides users through the recommended start path without changing layout or features.

### Description
- Change navigation container in `app/components/FamilyTopNavShell.tsx` from `hidden ... lg:flex` to `flex ... overflow-x-auto` so the primary nav (My Day → My Calendar → My Plan → My Programs + Outputs dropdown) is visible on all breakpoints and can scroll when space is tight.
- Update wording in `app/components/day/MyDayOverviewComponents.tsx` to retitle the quick-links area to `Where to start`, make the workflow order explicit (Calendar → Programs → Plan → Capture), and clarify that Outputs are for reflection while Community remains separate.

### Testing
- Verified presence of core auth pages with `for p in '/curriculum' '/my-portfolio' '/my-reports' '/my-progress' '/my-day' '/my-calendar' '/my-plan' '/my-programs' '/capture' '/community'; do test -f "app/(auth)$p/page.tsx" ...; done` and received `ok` for each expected page.
- Ran `npm run build` which attempted to start the Next build but failed in this environment with `sh: 1: next: not found` (build cannot complete here due to missing `next`).
- Committed the changes; no other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed72c899c083288d36968cbdd7f81a)