### PR TITLE
Add PR consolidation record and mark #18 superseded by #20

### DIFF
--- a/docs/pr_cleanup_consolidation_2026-04-26.md
+++ b/docs/pr_cleanup_consolidation_2026-04-26.md
@@ -1,0 +1,36 @@
+# PR Cleanup and Consolidation (2026-04-26)
+
+## Scope
+Consolidate overlapping open pull requests for My Programs, navigation coherence, and Community flow.
+
+## PRs inspected
+- PR #18 — My Programs onboarding/gating/handoff copy
+- PR #19 — Navigation and My Day start-path coherence
+- PR #20 — My Programs flow messaging and gating
+- PR #10 — Community posting/reply flow (already applied/obsolete)
+
+## Consolidation decision
+
+### PR #18 vs PR #20
+- PR #20 is treated as the canonical My Programs polish PR.
+- PR #18 is superseded by PR #20 and should be closed as superseded.
+
+### PR #19 relationship
+- PR #19 is separate from the My Programs copy/messaging scope.
+- PR #19 should remain open and be merged before PR #20.
+
+### PR #10 status
+- PR #10 should be closed as already applied/obsolete, with no further code movement required.
+
+## Recommended merge order
+1. PR #19 (navigation and My Day start-path coherence)
+2. PR #20 (canonical My Programs messaging/gating polish)
+
+## Overlap/conflict summary
+- Overlap exists between PR #18 and PR #20 in My Programs onboarding/gating/handoff copy.
+- PR #19 is adjacent but non-overlapping in purpose and should land first to preserve navigation/start-path baseline.
+- PR #10 has no remaining actionable diff in this consolidation flow.
+
+## Code change policy
+- No product functionality changes were introduced.
+- This file records consolidation outcomes only.


### PR DESCRIPTION
### Motivation
- Clean up overlapping open PRs so `main` receives changes in the intended order and reduce duplicate review effort.
- Establish a single canonical My Programs polish PR and clarify the status of adjacent PRs to avoid merge conflicts and confusion.

### Description
- Add `docs/pr_cleanup_consolidation_2026-04-26.md` which records that PR #20 is the canonical My Programs polish and that PR #18 is superseded and should be closed.
- Record that PR #19 is separate and should be merged before PR #20 and that PR #10 is already applied/obsolete and should be closed.
- This is a documentation-only change and does not modify any product code or introduce new functionality.

### Testing
- Ran `git status --short --branch` to confirm the working tree state, which succeeded.
- Committed the new file with `git add docs/pr_cleanup_consolidation_2026-04-26.md && git commit -m "Add PR consolidation decision record for #18 #19 #20 #10"`, which succeeded.
- Verified the file contents with `nl -ba docs/pr_cleanup_consolidation_2026-04-26.md`, which succeeded.
- No unit or integration tests were required because the change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed762d29488328bfc1deb3d0d9ca6f)