### PR TITLE
Refine My Programs readiness states, copy and generation gating

### DIFF
--- a/app/components/FamilyProgramsWorkspace.tsx
+++ b/app/components/FamilyProgramsWorkspace.tsx
@@ -207,12 +207,20 @@ export default function FamilyProgramsWorkspace() {
   const hasPrograms = loadedProgramCount > 0;
   const hasVisiblePrograms = programs.length > 0;
   const hasGeneratedItems = generatedBlockCount > 0;
+  const hasLearnerSelected = Boolean(activeLearner?.id);
+  const hasProgramSegments = Boolean(selectedProgram?.segments.length);
   const hasMapping = Boolean(
     selectedProgram?.scheduleMapping?.calendarTemplateSlotId && selectedProgram?.scheduleMapping?.startDate,
   );
   const isFirstRun = !hasGeneratedItems && (!hasCalendarTemplate || !hasPrograms);
   const generationReady = Boolean(
-    selectedProgram && assignmentTemplateId && assignmentSlotId && assignmentStartDate && hasCalendarTemplate,
+    selectedProgram &&
+      assignmentTemplateId &&
+      assignmentSlotId &&
+      assignmentStartDate &&
+      hasCalendarTemplate &&
+      hasLearnerSelected &&
+      hasProgramSegments,
   );
 
   const selectedSegment =
@@ -253,7 +261,7 @@ export default function FamilyProgramsWorkspace() {
     setPrograms((current) => [next, ...current]);
     setSelectedProgramId(next.id);
     setLoadedProgramCount((current) => Math.max(current, 1));
-    setStatus("A starter program is ready to shape.");
+    setStatus("Starter program ready. Next: add or edit segments.");
     setError("");
   }
 
@@ -318,7 +326,7 @@ export default function FamilyProgramsWorkspace() {
       };
       const saved = await saveFamilyProgram(nextProgram);
       updateProgram(saved);
-      setStatus("Program saved.");
+      setStatus("Program saved. When ready, generate it into My Plan.");
     } catch {
       setError(friendlyProgramsMessage("save"));
     } finally {
@@ -363,7 +371,7 @@ export default function FamilyProgramsWorkspace() {
       setGeneratedBlockCount((current) => current + generated.length);
       setLastGeneratedCount(generated.length);
       setShowGenerationSuccess(true);
-      setStatus(`${generated.length} live planning block${generated.length === 1 ? "" : "s"} generated into My Plan.`);
+      setStatus(`${generated.length} block${generated.length === 1 ? "" : "s"} generated into My Plan.`);
     } catch {
       setError(friendlyProgramsMessage("generate"));
     } finally {
@@ -398,8 +406,8 @@ export default function FamilyProgramsWorkspace() {
 
         {!workspaceLoading && !activeLearner ? (
           <ProgramsGuidedSetupBanner
-            title="You can set up rhythm and sequence before choosing a learner"
-            note="My Calendar and My Programs can be shaped now. Choose a learner when you want generated planning to feel specific inside My Plan and My Day."
+            title="You can build here now"
+            note="Choose a learner before generating into My Plan."
           />
         ) : null}
 
@@ -426,22 +434,22 @@ export default function FamilyProgramsWorkspace() {
 
         {!isFirstRun && hasCalendarTemplate && !hasPrograms ? (
           <ProgramsGuidedSetupBanner
-            title="Your weekly rhythm is ready. Now let's build your program."
-            note="Start with a sample program, rename a few segments, then map it into one My Calendar slot."
+            title="Your weekly rhythm is ready"
+            note="Start with a sample program, then add segments."
           />
         ) : null}
 
         {!isFirstRun && hasVisiblePrograms && !hasMapping && !showGenerationSuccess ? (
           <ProgramsGuidedSetupBanner
-            title="Choose where this program should land next"
-            note="Assign the current program to one reusable My Calendar slot so it can flow into your live week."
+            title="Map this program to one slot"
+            note="Pick the My Calendar slot and start date to unlock generation."
           />
         ) : null}
 
         {!isFirstRun && hasVisiblePrograms && hasMapping && !hasGeneratedItems && !showGenerationSuccess ? (
           <ProgramsGuidedSetupBanner
-            title="You're one step away from the live week"
-            note="Choose the start date, then generate this sequence into My Plan and review it in My Day."
+            title="Ready to generate"
+            note="Generate into My Plan, then review in My Day."
           />
         ) : null}
 
@@ -467,7 +475,7 @@ export default function FamilyProgramsWorkspace() {
                   <div className="grid gap-1.5">
                     <div className={LABEL}>Segments</div>
                     <h2 className={H2}>Build the sequence</h2>
-                    <p className={BODY}>Keep each segment lightweight. It only needs enough detail to make live planning easier later.</p>
+                    <p className={BODY}>Add segments in order so the next step is clear.</p>
                   </div>
                   <button
                     type="button"
@@ -543,6 +551,8 @@ export default function FamilyProgramsWorkspace() {
                 onGenerate={() => void handleGenerate()}
                 generating={generating}
                 generationReady={generationReady}
+                hasLearner={hasLearnerSelected}
+                hasSegments={hasProgramSegments}
               />
 
               <section className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-[0_10px_28px_rgba(15,23,42,0.04)]">
@@ -557,7 +567,11 @@ export default function FamilyProgramsWorkspace() {
                         ? "Choose a reusable slot first, then generation will become available."
                       : !assignmentStartDate
                         ? "Choose a start date to complete the setup for generation."
-                          : "Assign this program to My Calendar, then generate it into My Plan.")}
+                        : !hasLearnerSelected
+                          ? "Choose a learner above to generate into My Plan."
+                          : !hasProgramSegments
+                            ? "Add at least one segment before generating."
+                            : "Ready. Generate this program into My Plan.")}
                 </div>
                 <div className="mt-4 flex gap-3">
                   <button

--- a/app/components/programs/ProgramOverviewComponents.tsx
+++ b/app/components/programs/ProgramOverviewComponents.tsx
@@ -79,9 +79,7 @@ export function ProgramsFirstRunCard({
       <div className="grid gap-1.5">
         <div className={LABEL}>Getting started</div>
         <h2 className={H2}>Build your first program</h2>
-        <p className={BODY}>
-          My Programs is where the longer sequence comes together before it drops into My Calendar and opens into My Plan.
-        </p>
+        <p className={BODY}>Build the sequence here, then place it into My Plan.</p>
       </div>
 
       <div className="grid gap-3 md:grid-cols-3">
@@ -199,8 +197,8 @@ export function ProgramList({
 }) {
   const heading = firstRun ? "Your first program is ready to shape" : "Shape the longer sequence before it reaches the live week";
   const support = firstRun
-    ? "Start with the sample program below, rename what you need, then map it into one calendar slot."
-    : "Build reusable units, terms, or sequences here, then place them into My Calendar so they can flow into My Plan.";
+    ? "Start with the sample, rename it, then map it to one slot."
+    : "Shape your sequence here, then generate it into My Plan.";
 
   return (
     <section className="grid gap-4 rounded-[24px] border border-slate-200 bg-white p-5 shadow-[0_10px_28px_rgba(15,23,42,0.04)]">
@@ -304,9 +302,7 @@ export function ProgramEditor({
       <div className="grid gap-1.5">
         <div className={LABEL}>Your first program</div>
         <h2 className={H2}>Shape this program</h2>
-        <p className={BODY}>
-          Start by renaming the title or adjusting one segment. You can refine the rest after it reaches the live week.
-        </p>
+        <p className={BODY}>Rename the program, then shape the segments.</p>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
@@ -440,6 +436,8 @@ export function ProgramCalendarAssignmentPanel({
   onGenerate,
   generating,
   generationReady,
+  hasLearner,
+  hasSegments,
 }: {
   templates: CalendarTemplate[];
   selectedTemplateId: string;
@@ -451,6 +449,8 @@ export function ProgramCalendarAssignmentPanel({
   onGenerate: () => void;
   generating?: boolean;
   generationReady: boolean;
+  hasLearner: boolean;
+  hasSegments: boolean;
 }) {
   const selectedTemplate =
     templates.find((template) => template.id === selectedTemplateId) ?? null;
@@ -466,6 +466,10 @@ export function ProgramCalendarAssignmentPanel({
           ? "ready_choose_slot"
           : !startDate
             ? "ready_choose_date"
+            : !hasLearner
+              ? "blocked_learner"
+              : !hasSegments
+                ? "blocked_segments"
             : generationReady
               ? "ready_generate"
               : "partial";
@@ -478,6 +482,10 @@ export function ProgramCalendarAssignmentPanel({
           ? "Choose a slot to continue"
           : state === "ready_choose_date"
             ? "Choose when this sequence should begin"
+            : state === "blocked_learner"
+              ? "Choose a learner to generate"
+              : state === "blocked_segments"
+                ? "Add at least one segment"
             : state === "ready_generate"
               ? "Generate into My Plan"
               : "Choose where this program should land";
@@ -487,9 +495,13 @@ export function ProgramCalendarAssignmentPanel({
       : state === "blocked_slots"
         ? "This template exists, but it still needs at least one reusable slot before generation can begin."
         : state === "ready_choose_slot"
-          ? "Pick the slot that best matches where this program should usually land in the week."
-          : state === "ready_choose_date"
-            ? "Choose the first week this program should begin, then generation will become available."
+        ? "Pick the slot that best matches where this program should usually land in the week."
+        : state === "ready_choose_date"
+          ? "Choose the first week this program should begin, then generation will become available."
+          : state === "blocked_learner"
+            ? "Generation needs a learner so blocks can be placed into the right plan."
+            : state === "blocked_segments"
+              ? "This program needs at least one segment before it can generate."
             : state === "ready_generate"
               ? "This will place each segment into the next matching week and open those generated blocks in My Plan for live adjustment."
               : "Assign this program to a reusable calendar slot, then choose when to start.";
@@ -592,6 +604,10 @@ export function ProgramCalendarAssignmentPanel({
           <div className={META}>Choose a slot to continue.</div>
         ) : !startDate ? (
           <div className={META}>Choose when this sequence should begin.</div>
+        ) : !hasLearner ? (
+          <div className={META}>Choose a learner above to continue.</div>
+        ) : !hasSegments ? (
+          <div className={META}>Add at least one segment to continue.</div>
         ) : (
           <div className={META}>
             The first segment will land in the first matching week, then the rest will flow forward one week at a time.


### PR DESCRIPTION
### Motivation
- Make every My Programs state feel intentional, scannable and actionable by removing ambiguous copy and silent failure states.
- Prevent users from attempting generation when key prerequisites are missing by surfacing clear, explanatory blocking reasons.
- Keep a single dominant primary CTA and clear next-step guidance after create/save/generate actions.

### Description
- Tightened copy across the first-run and editor surfaces in `app/components/programs/ProgramOverviewComponents.tsx` to improve scanability and shorten long paragraphs (e.g. onboarding, first-run guidance, editor hints). 
- Added explicit readiness gating in `app/components/FamilyProgramsWorkspace.tsx` by introducing `hasLearnerSelected` and `hasProgramSegments` and requiring them in the `generationReady` check so `Generate into My Plan` only becomes enabled when template, slot, date, learner and at least one segment are present.
- Extended `ProgramCalendarAssignmentPanel` to accept `hasLearner` and `hasSegments` props and added new blocked states and explanatory panel titles/notes for missing learner and missing segments, so blocked states explain why and what to do next.
- Simplified status and banner messaging after create/save/generate to be concise and actionable (e.g. show the next step after creating a starter program and after saving). 

### Testing
- Attempted to run a production build with `npm run build` in the workspace; the command failed in this environment with `sh: 1: next: not found`, preventing a full build verification.
- No automated unit or integration tests were added or run as part of this change in this environment; changes are limited to UI copy, gating logic, and component props so follow-up build in a Next.js-enabled environment is required for full verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec6070b6483289acb5a1908441fc6)