### PR TITLE
Polish Community UX: clarity for categories, threads, and reply flow

### DIFF
--- a/app/(auth)/community/[categorySlug]/[threadId]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/[threadId]/page.tsx
@@ -70,7 +70,8 @@ export default function CommunityThreadPage() {
   const [replyBody, setReplyBody] = useState("");
   const [replying, setReplying] = useState(false);
   const [supporting, setSupporting] = useState(false);
-  const [message, setMessage] = useState("");
+  const [replyMessage, setReplyMessage] = useState("");
+  const [supportMessage, setSupportMessage] = useState("");
 
   useEffect(() => {
     let mounted = true;
@@ -118,16 +119,16 @@ export default function CommunityThreadPage() {
   async function handleReply() {
     if (!thread) return;
     if (!viewerId) {
-      setMessage("Sign in to reply");
+      setReplyMessage("Sign in to reply");
       return;
     }
     if (!replyBody.trim()) {
-      setMessage("Write a reply first.");
+      setReplyMessage("Write your reply before posting.");
       return;
     }
 
     setReplying(true);
-    setMessage("");
+    setReplyMessage("");
 
     try {
       const result = await createForumReply({
@@ -152,9 +153,10 @@ export default function CommunityThreadPage() {
           : current,
       );
       setReplyBody("");
+      setReplyMessage("Reply posted. It now appears in this conversation.");
     } catch (error) {
       console.error("Reply failed", error);
-      setMessage("That reply could not be posted right now.");
+      setReplyMessage("Your reply could not be posted right now.");
     } finally {
       setReplying(false);
     }
@@ -163,12 +165,12 @@ export default function CommunityThreadPage() {
   async function handleSupport() {
     if (!thread || thread.viewerSupports) return;
     if (!viewerId) {
-      setMessage("Sign in to support this idea.");
+      setSupportMessage("Sign in to support this idea.");
       return;
     }
 
     setSupporting(true);
-    setMessage("");
+    setSupportMessage("");
 
     try {
       const result = await supportForumThread({
@@ -185,9 +187,10 @@ export default function CommunityThreadPage() {
             }
           : current,
       );
+      setSupportMessage("Thanks for supporting this idea.");
     } catch (error) {
       console.error("Support failed", error);
-      setMessage("Support could not be saved right now.");
+      setSupportMessage("Support could not be saved right now.");
     } finally {
       setSupporting(false);
     }
@@ -205,7 +208,7 @@ export default function CommunityThreadPage() {
       heroTitle={thread?.title || "Community"}
       heroText="A structured member conversation with one clear starting post and calm chronological replies."
       hideHeroAside={true}
-      workflowHelperText="Community threads stay simple: one opening post, then a readable reply list."
+      workflowHelperText="Community threads stay simple: one opening post, then clear and thoughtful replies."
     >
       {loading ? (
         <section
@@ -314,6 +317,10 @@ export default function CommunityThreadPage() {
               <div style={{ fontSize: 12, color: "#64748b", fontWeight: 700 }}>
                 {thread.authorLabel} - {relativeTime(thread.created_at)}
               </div>
+              <div style={{ fontSize: 12, color: "#64748b", fontWeight: 700 }}>
+                {thread.replyCount} repl{thread.replyCount === 1 ? "y" : "ies"} • Latest activity{" "}
+                {relativeTime(thread.latestActivityAt)}
+              </div>
               <div style={{ fontSize: 15, lineHeight: 1.75, color: "#334155", whiteSpace: "pre-wrap" }}>
                 {thread.body}
               </div>
@@ -366,11 +373,19 @@ export default function CommunityThreadPage() {
                         ? "Saving..."
                         : "Support this idea"}
                 </button>
+                {supportMessage ? (
+                  <div style={{ fontSize: 12, lineHeight: 1.6, color: "#64748b", fontWeight: 700 }}>
+                    {supportMessage}
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </section>
 
           <section style={{ display: "grid", gap: 14, marginBottom: 18 }}>
+            <div style={{ fontSize: 12, fontWeight: 900, letterSpacing: 1.1, textTransform: "uppercase", color: "#64748b" }}>
+              Replies
+            </div>
             {replies.length === 0 ? (
               <article
                 style={{
@@ -384,10 +399,10 @@ export default function CommunityThreadPage() {
                 }}
               >
                 <div style={{ fontSize: 16, fontWeight: 900, color: "#0f172a" }}>
-                  This conversation is ready for the first reply.
+                  No replies yet.
                 </div>
                 <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569" }}>
-                  Add a thoughtful response to help the discussion begin.
+                  When someone responds, the conversation will appear here.
                 </div>
               </article>
             ) : (
@@ -427,6 +442,9 @@ export default function CommunityThreadPage() {
             }}
           >
             <div style={{ fontSize: 18, fontWeight: 900, color: "#0f172a" }}>Reply to this discussion</div>
+            <div style={{ fontSize: 13, lineHeight: 1.6, color: "#64748b" }}>
+              Your reply is posted to this thread and shown in time order.
+            </div>
             <textarea
               value={replyBody}
               onChange={(e) => setReplyBody(e.target.value)}
@@ -450,8 +468,11 @@ export default function CommunityThreadPage() {
                 resize: "vertical",
               }}
             />
-            {message ? (
-              <div style={{ fontSize: 13, color: "#475569", fontWeight: 700 }}>{message}</div>
+            {!canReply ? (
+              <div style={{ fontSize: 13, color: "#64748b", fontWeight: 700 }}>Sign in to reply</div>
+            ) : null}
+            {replyMessage ? (
+              <div style={{ fontSize: 13, color: "#475569", fontWeight: 700 }}>{replyMessage}</div>
             ) : null}
             <div>
               <button
@@ -472,6 +493,9 @@ export default function CommunityThreadPage() {
               >
                 {!canReply ? "Sign in to reply" : replying ? "Posting..." : "Post reply"}
               </button>
+            </div>
+            <div style={{ fontSize: 12, color: "#64748b", lineHeight: 1.6 }}>
+              Keep replies practical, kind, and family-focused.
             </div>
           </section>
         </>

--- a/app/(auth)/community/[categorySlug]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/page.tsx
@@ -10,6 +10,7 @@ import {
   createForumThread,
   isFeatureSuggestionCategory,
   loadCategoryPageData,
+  relativeTime,
   requireCommunityUserId,
   type ForumCategory,
   type ForumThreadSummary,
@@ -174,10 +175,13 @@ export default function CommunityCategoryPage() {
   } as ForumCategory);
   const isFeatureCategory = isFeatureSuggestionCategory(resolvedCategory);
   const canStartDiscussion = Boolean(viewerId);
+  const latestActivityLabel = threads.length
+    ? `Latest activity ${relativeTime(threads[0].latestActivityAt)}`
+    : "No activity yet";
 
   async function handleCreateThread() {
     if (!threadTitle.trim() || !threadBody.trim()) {
-      setMessage("Add a title and message to start the conversation.");
+      setMessage("Add a title and opening post so families can quickly understand your conversation.");
       return;
     }
 
@@ -197,7 +201,7 @@ export default function CommunityCategoryPage() {
         body: threadBody,
       });
 
-      setMessage("Conversation started. Opening discussion...");
+      setMessage("Conversation posted. Opening your new thread...");
       router.push(buildCommunityThreadHref(resolvedCategory.slug, result.thread.id));
     } catch (error) {
       console.error("Create thread failed", error);
@@ -214,7 +218,7 @@ export default function CommunityCategoryPage() {
       heroTitle={resolvedCategory.name}
       heroText={resolvedCategory.description}
       hideHeroAside={true}
-      workflowHelperText="Community categories stay calm and readable: a clear title, recent discussions, and one simple path to start a new thread."
+      workflowHelperText="Community categories stay calm and readable: scan recent conversations, then start one clear discussion when needed."
     >
       <section
         style={{
@@ -247,6 +251,34 @@ export default function CommunityCategoryPage() {
             </div>
             <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569", marginTop: 8, maxWidth: 760 }}>
               {resolvedCategory.description}
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 10 }}>
+              <span
+                style={{
+                  border: "1px solid #dbeafe",
+                  background: "#eff6ff",
+                  color: "#1d4ed8",
+                  borderRadius: 999,
+                  padding: "5px 10px",
+                  fontSize: 12,
+                  fontWeight: 800,
+                }}
+              >
+                {threads.length} conversation{threads.length === 1 ? "" : "s"}
+              </span>
+              <span
+                style={{
+                  border: "1px solid #e2e8f0",
+                  background: "#f8fafc",
+                  color: "#475569",
+                  borderRadius: 999,
+                  padding: "5px 10px",
+                  fontSize: 12,
+                  fontWeight: 700,
+                }}
+              >
+                {latestActivityLabel}
+              </span>
             </div>
           </div>
 
@@ -314,10 +346,13 @@ export default function CommunityCategoryPage() {
             }}
           >
             <div style={{ fontSize: 16, fontWeight: 900, color: "#0f172a" }}>Start a conversation</div>
+            <div style={{ fontSize: 13, lineHeight: 1.6, color: "#64748b" }}>
+              Start with one question, resource, or idea that could help another family.
+            </div>
             <input
               value={threadTitle}
               onChange={(event) => setThreadTitle(event.target.value)}
-              placeholder="Discussion title"
+              placeholder={isFeatureCategory ? "Idea title" : "Conversation title"}
               style={{
                 width: "100%",
                 border: "1px solid #d1d5db",
@@ -331,7 +366,11 @@ export default function CommunityCategoryPage() {
               value={threadBody}
               onChange={(event) => setThreadBody(event.target.value)}
               rows={5}
-              placeholder="Write the opening post for this conversation."
+              placeholder={
+                isFeatureCategory
+                  ? "Describe what would help your family and why."
+                  : "Share the context and the question or resource you want to discuss."
+              }
               style={{
                 width: "100%",
                 border: "1px solid #d1d5db",
@@ -363,6 +402,9 @@ export default function CommunityCategoryPage() {
               >
                 {savingThread ? "Starting..." : "Start conversation"}
               </button>
+            </div>
+            <div style={{ fontSize: 12, color: "#64748b", lineHeight: 1.6 }}>
+              Keep conversations practical, kind, and family-focused.
             </div>
           </div>
         ) : null}
@@ -396,7 +438,7 @@ export default function CommunityCategoryPage() {
             {fallback.emptyTitle}
           </div>
           <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569" }}>
-            {fallback.emptyText}
+            No conversations here yet. This area is ready for the first question or resource.
           </div>
           <div>
             {canStartDiscussion ? (
@@ -437,6 +479,9 @@ export default function CommunityCategoryPage() {
         </section>
       ) : (
         <section style={{ display: "grid", gap: 14 }}>
+          <div style={{ fontSize: 12, fontWeight: 900, letterSpacing: 1.1, textTransform: "uppercase", color: "#64748b" }}>
+            Conversations
+          </div>
           {threads.map((thread) => (
             <ForumThreadRow key={thread.id} thread={thread} />
           ))}

--- a/app/(auth)/community/new/page.tsx
+++ b/app/(auth)/community/new/page.tsx
@@ -130,21 +130,21 @@ export default function CommunityComposePage() {
       ? "Help shape MyLearna"
       : selectedCategory.slug === "homeschool-resources"
         ? "Share a resource"
-        : "Start a discussion";
+        : "Start a conversation";
 
   const titlePlaceholder =
     selectedCategory.slug === "homeschool-resources"
       ? "Resource title"
       : selectedCategory.slug === "general-discussion"
-        ? "Question or discussion title"
-        : "Discussion title";
+        ? "Question or conversation title"
+        : "Conversation title";
 
   const bodyPlaceholder =
     selectedCategory.slug === "help-shape-edudecks"
       ? "Describe the idea, the problem it solves, and how it would help your family."
       : selectedCategory.slug === "homeschool-resources"
         ? "Share the resource, why it helped, and who it might suit."
-        : "Write your opening post";
+        : "Share context so families can reply in a helpful way.";
 
   async function handleSubmit() {
     if (!viewerId) {
@@ -153,12 +153,12 @@ export default function CommunityComposePage() {
     }
 
     if (!title.trim()) {
-      setMessage("Add a title first.");
+      setMessage("Add a clear title so families can scan this conversation quickly.");
       return;
     }
 
     if (!body.trim()) {
-      setMessage("Add a message before posting.");
+      setMessage("Add your opening message before posting.");
       return;
     }
 
@@ -184,7 +184,7 @@ export default function CommunityComposePage() {
       router.push(buildCommunityThreadHref(selectedCategory.slug, result.thread.id));
     } catch (error) {
       console.error("Create thread failed", error);
-      setMessage("That discussion could not be posted right now.");
+      setMessage("Your conversation could not be posted right now.");
     } finally {
       setSaving(false);
     }
@@ -195,9 +195,9 @@ export default function CommunityComposePage() {
       title="MyLearna Family"
       subtitle="Community"
       heroTitle={composerTitle}
-      heroText="Start a calm, readable discussion with one clear opening post."
+      heroText="Start a calm, readable conversation with one clear opening post."
       hideHeroAside={true}
-      workflowHelperText="Community threads stay simple: choose a category, write one strong opening post, and let replies build from there."
+      workflowHelperText="Choose the right category, share clear context, and help families reply with practical support."
     >
       <section
         style={{
@@ -222,13 +222,16 @@ export default function CommunityComposePage() {
                 marginBottom: 8,
               }}
             >
-              New thread
+              New conversation
             </div>
             <div style={{ fontSize: 28, lineHeight: 1.15, fontWeight: 900, color: "#0f172a" }}>
               {composerTitle}
             </div>
             <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569", marginTop: 8, maxWidth: 760 }}>
-              Choose the right category, then write one clear opening post that helps other families understand the conversation.
+              Choose the right category, then share one clear opening post so families can understand how to help.
+            </div>
+            <div style={{ fontSize: 12, lineHeight: 1.6, color: "#64748b", marginTop: 8 }}>
+              Keep posts practical, kind, and family-focused.
             </div>
           </div>
 
@@ -246,7 +249,7 @@ export default function CommunityComposePage() {
                 textDecoration: "none",
               }}
             >
-              Back
+              Back to category
             </Link>
           </div>
         </div>
@@ -294,7 +297,7 @@ export default function CommunityComposePage() {
           </label>
 
           <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontSize: 13, fontWeight: 800, color: "#334155" }}>Message</span>
+            <span style={{ fontSize: 13, fontWeight: 800, color: "#334155" }}>Opening post</span>
             <textarea
               value={body}
               onChange={(event) => setBody(event.target.value)}
@@ -335,9 +338,9 @@ export default function CommunityComposePage() {
                 opacity: saving || !canPost ? 0.8 : 1,
               }}
             >
-              {!canPost ? "Sign in to start a conversation" : saving ? "Posting..." : "Post discussion"}
-            </button>
-          </div>
+                {!canPost ? "Sign in to start a conversation" : saving ? "Posting..." : "Post conversation"}
+              </button>
+            </div>
         </div>
       </section>
     </FamilyTopNavShell>


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy, wording, and scanability across Community pages so conversations feel calm, readable, and family‑focused.
- Make the start/reply flows explicit and truthful for signed‑out users while keeping all existing wiring and no new backend/schema features.

### Description
- Refined copy and small UI additions on three pages: `app/(auth)/community/[categorySlug]/page.tsx`, `app/(auth)/community/[categorySlug]/[threadId]/page.tsx`, and `app/(auth)/community/new/page.tsx` to tighten tone and clarify purpose. 
- Category page: added conversation and latest‑activity chips, a “Conversations” section heading, calmer empty‑state copy, and clearer composer guidance and placeholders. 
- Thread page: added explicit reply count + latest activity metadata near the original post, a “Replies” heading, clearer no‑replies copy, and split reply vs support feedback messages (success/error). 
- New thread page: reframed “thread”→“conversation”, clarified title/body placeholders and validation messages, and added light trust/safety guidance text; CTAs remain wired to existing create flows. 

### Testing
- Attempted `npm run build` in the environment and it failed with `sh: 1: next: not found`. 
- `npm install` was attempted but the environment showed install warnings/limits and did not produce a successful `next build` in this session. 
- Code changes were lint/inspected by opening the three modified files and validated that existing routes and handlers (create thread/reply/support) remain used and unchanged; no automated unit tests were added or run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec9c511048328b4b6b74298feea53)