### PR TITLE
Polish My Programs typography and generation handoff copy

### DIFF
--- a/app/components/programs/ProgramOverviewComponents.tsx
+++ b/app/components/programs/ProgramOverviewComponents.tsx
@@ -11,7 +11,7 @@ import type {
 export const LABEL = "text-[12px] font-semibold uppercase tracking-[0.18em] text-slate-500";
 export const H2 = "text-[18px] font-bold tracking-tight text-slate-950";
 export const H3 = "text-[15px] font-semibold text-slate-950";
-export const BODY = "text-[14px] leading-6 text-slate-600";
+export const BODY = "text-[14px] leading-5 text-slate-600";
 export const META = "text-[13px] leading-5 text-slate-500";
 export const INPUT =
   "w-full rounded-[14px] border border-slate-200 bg-white px-4 py-3 text-[14px] text-slate-900 outline-none transition focus:border-blue-200 focus:ring-4 focus:ring-blue-100";
@@ -162,7 +162,7 @@ export function ProgramGenerationSuccessBanner({
         <p className={BODY}>
           {count} live planning block{count === 1 ? "" : "s"} {count === 1 ? "is" : "are"} ready in My Plan and can be adjusted there at any time.
         </p>
-        <p className={META}>Open My Plan to view the generated week, or stay here and keep refining the sequence.</p>
+        <p className={META}>Program generated into My Plan. Open My Plan to adjust the week.</p>
       </div>
       <div className="flex flex-wrap gap-3">
         <button


### PR DESCRIPTION
### Motivation
- Improve scanability of body copy in the My Programs overview and restore a clearer handoff message after generation so users know the next action.

### Description
- In `app/components/programs/ProgramOverviewComponents.tsx` updated `export const BODY` from `text-[14px] leading-6 text-slate-600` to `text-[14px] leading-5 text-slate-600` and replaced the generation success helper line with `Program generated into My Plan. Open My Plan to adjust the week.`

### Testing
- Attempted `npm run build`, which failed in this environment because the `next` binary is not available (`sh: 1: next: not found`), so no build or automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed76f24e48328b87f04c8a6146d23)