### PR TITLE
Polish tone and CTA consistency across My Day and Community

### DIFF
--- a/app/(auth)/community/[categorySlug]/[threadId]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/[threadId]/page.tsx
@@ -118,7 +118,7 @@ export default function CommunityThreadPage() {
   async function handleReply() {
     if (!thread) return;
     if (!viewerId) {
-      setMessage("Sign in to reply");
+      setMessage("Sign in to reply.");
       return;
     }
     if (!replyBody.trim()) {
@@ -232,6 +232,10 @@ export default function CommunityThreadPage() {
           }}
         >
           <div style={{ fontSize: 20, fontWeight: 900, color: "#0f172a" }}>Thread not found</div>
+          <div style={{ fontSize: 14, lineHeight: 1.6, color: "#475569" }}>
+            This discussion may have moved or been removed. Open Community to choose another
+            conversation.
+          </div>
           <Link href="/community" style={{ color: "#2563eb", fontWeight: 800, textDecoration: "none" }}>
             Back to Community
           </Link>
@@ -359,7 +363,7 @@ export default function CommunityThreadPage() {
                   }}
                 >
                   {!viewerId
-                    ? "Sign in to support this idea"
+                    ? "Sign in to support this idea."
                     : thread.viewerSupports
                       ? "You support this idea"
                       : supporting
@@ -434,7 +438,7 @@ export default function CommunityThreadPage() {
               disabled={!canReply || replying}
               placeholder={
                 !canReply
-                  ? "Sign in to reply"
+                  ? "Sign in to reply."
                   : isFeatureCategory
                   ? "Add a thoughtful reply or build on the idea"
                   : "Add a thoughtful reply"
@@ -470,7 +474,7 @@ export default function CommunityThreadPage() {
                   opacity: replying || !canReply ? 0.8 : 1,
                 }}
               >
-                {!canReply ? "Sign in to reply" : replying ? "Posting..." : "Post reply"}
+                {!canReply ? "Sign in to reply." : replying ? "Posting..." : "Post reply"}
               </button>
             </div>
           </section>

--- a/app/(auth)/community/[categorySlug]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/page.tsx
@@ -182,7 +182,7 @@ export default function CommunityCategoryPage() {
     }
 
     if (!viewerId) {
-      setMessage("Sign in to start a conversation");
+      setMessage("Sign in to start a conversation.");
       return;
     }
 
@@ -264,7 +264,7 @@ export default function CommunityCategoryPage() {
                 textDecoration: "none",
               }}
             >
-              Back to categories
+              Back to Community
             </Link>
             {canStartDiscussion ? (
               <button
@@ -296,7 +296,7 @@ export default function CommunityCategoryPage() {
                   display: "inline-flex",
                 }}
               >
-                Sign in to start a conversation
+                Sign in to start a conversation.
               </span>
             )}
           </div>
@@ -331,7 +331,7 @@ export default function CommunityCategoryPage() {
               value={threadBody}
               onChange={(event) => setThreadBody(event.target.value)}
               rows={5}
-              placeholder="Write the opening post for this conversation."
+              placeholder="Write one clear opening post for this discussion."
               style={{
                 width: "100%",
                 border: "1px solid #d1d5db",
@@ -430,7 +430,7 @@ export default function CommunityCategoryPage() {
                   display: "inline-flex",
                 }}
               >
-                Sign in to start a conversation
+                Sign in to start a conversation.
               </span>
             )}
           </div>

--- a/app/(auth)/community/new/page.tsx
+++ b/app/(auth)/community/new/page.tsx
@@ -91,7 +91,7 @@ export default function CommunityComposePage() {
 
         if (!userId) {
           setCategories(FALLBACK_OPTIONS);
-          setMessage("Sign in to start a conversation");
+          setMessage("Sign in to start a conversation.");
           return;
         }
 
@@ -148,7 +148,7 @@ export default function CommunityComposePage() {
 
   async function handleSubmit() {
     if (!viewerId) {
-      setMessage("Sign in to start a conversation");
+      setMessage("Sign in to start a conversation.");
       return;
     }
 
@@ -228,7 +228,8 @@ export default function CommunityComposePage() {
               {composerTitle}
             </div>
             <div style={{ fontSize: 14, lineHeight: 1.7, color: "#475569", marginTop: 8, maxWidth: 760 }}>
-              Choose the right category, then write one clear opening post that helps other families understand the conversation.
+              Choose the right category, then write one clear opening post so other families can
+              follow and reply.
             </div>
           </div>
 
@@ -246,7 +247,7 @@ export default function CommunityComposePage() {
                 textDecoration: "none",
               }}
             >
-              Back
+              Back to category
             </Link>
           </div>
         </div>
@@ -335,7 +336,7 @@ export default function CommunityComposePage() {
                 opacity: saving || !canPost ? 0.8 : 1,
               }}
             >
-              {!canPost ? "Sign in to start a conversation" : saving ? "Posting..." : "Post discussion"}
+              {!canPost ? "Sign in to start a conversation." : saving ? "Posting..." : "Post discussion"}
             </button>
           </div>
         </div>

--- a/app/(auth)/community/page.tsx
+++ b/app/(auth)/community/page.tsx
@@ -441,7 +441,7 @@ export default function CommunityHomePage() {
 
         if (!userId) {
           setCategories(FALLBACK_CATEGORIES);
-          setMessage("Sign in to start a conversation");
+          setMessage("Sign in to start a conversation.");
           return;
         }
 
@@ -463,7 +463,7 @@ export default function CommunityHomePage() {
 
         setViewerId(null);
         setCategories(FALLBACK_CATEGORIES);
-        setMessage("Community data could not be loaded right now.");
+        setMessage("Community is not loading just yet. Please try again in a moment.");
       } finally {
         if (mounted) setLoading(false);
       }
@@ -538,20 +538,20 @@ export default function CommunityHomePage() {
             maxWidth: 860,
           }}
         >
-          Share ideas, ask questions, post resources, encourage other parents,
-          and start thoughtful discussions in the category that fits best.
+          Share ideas, ask questions, post resources, and encourage other parents in the category
+          that fits best.
         </div>
 
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
           {canStartDiscussion ? (
-            featuredActions.map((action) => (
+            featuredActions.map((action, index) => (
               <Link
                 key={action.label}
                 href={action.href}
                 style={{
-                  border: "1px solid #2563eb",
-                  background: "#2563eb",
-                  color: "#ffffff",
+                  border: index === 0 ? "1px solid #2563eb" : "1px solid #d1d5db",
+                  background: index === 0 ? "#2563eb" : "#ffffff",
+                  color: index === 0 ? "#ffffff" : "#334155",
                   borderRadius: 10,
                   padding: "10px 14px",
                   fontSize: 14,
@@ -574,7 +574,7 @@ export default function CommunityHomePage() {
                 fontWeight: 800,
               }}
             >
-              Sign in to start a conversation
+              Sign in to start a conversation.
             </span>
           )}
         </div>

--- a/app/components/MyDayWorkspace.tsx
+++ b/app/components/MyDayWorkspace.tsx
@@ -119,8 +119,8 @@ function TodayEmptyGuidance({
           Nothing is planned for today yet
         </div>
         <p className="max-w-[64ch] text-[14px] leading-6 text-slate-600">
-          Nothing is broken. My Day will fill in once you add a learning block, pull in your
-          calendar rhythm, or capture something that already happened today for {learnerName}.
+          My Day will fill in once you add a block in My Plan, shape your weekly rhythm in My
+          Calendar, or capture a learning moment for {learnerName}.
         </p>
       </div>
 
@@ -176,8 +176,8 @@ function TodayEmptyGuidance({
       </div>
 
       <p className="text-[12px] leading-5 text-slate-500">
-        You do not need a perfect plan to begin. One planned block or one captured learning moment
-        is enough to make today visible.
+        Start with one clear step. One planned block or one captured learning moment is enough to
+        make today visible.
       </p>
     </section>
   );
@@ -553,4 +553,3 @@ export default function MyDayWorkspace() {
     </FamilyTopNavShell>
   );
 }
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,22 +13,22 @@ const STEPS = [
   {
     number: "1",
     title: "Plan",
-    text: "Set a learning focus for the moment.",
+    text: "Set one clear learning step.",
   },
   {
     number: "2",
     title: "Capture",
-    text: "Record what actually happened.",
+    text: "Record what happened while it is fresh.",
   },
   {
     number: "3",
-    title: "Build",
-    text: "Turn moments into a structured learning record.",
+    title: "Reflect",
+    text: "Review what helped and what to adjust next.",
   },
   {
     number: "4",
-    title: "Report",
-    text: "See progress clearly over time.",
+    title: "Grow",
+    text: "Build a stronger record over time.",
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Make small, high-impact UX and copy tweaks so MyLearna feels calmer, more premium, and consistent end-to-end.
- Remove terse/technical or inconsistent microcopy and ensure one clear CTA emphasis per surface. 
- Apply only safe presentation and copy changes without altering data, routing, or backend behaviour.

### Description
- Aligned public homepage workflow language to the canonical Plan → Capture → Reflect → Grow model by updating `app/page.tsx` (landing step titles and microcopy).
- Tightened My Day empty-state guidance for clearer next steps and a more action-oriented tone in `app/components/MyDayWorkspace.tsx`.
- Polished Community surfaces (home, category list, thread view, compose) to normalize punctuation, calm tone, clearer placeholders, and an informative “thread not found” message in `app/(auth)/community/page.tsx`, `app/(auth)/community/[categorySlug]/page.tsx`, `app/(auth)/community/[categorySlug]/[threadId]/page.tsx`, and `app/(auth)/community/new/page.tsx`.
- Improved CTA hierarchy on the Community home by visually emphasizing one primary action and rendering sibling actions as secondary to avoid competing CTAs (styling-only changes).

### Testing
- Ran a targeted search for trust leaks and problem terms with `rg` to confirm visible brand/technical language coverage; the search completed and informed edits.  (Succeeded.)
- Attempted a full build with `npm run build`; the build could not be run in this environment because `next` was not available (`sh: 1: next: not found`). (Failed.)
- Attempted to install/repair dependencies with `npm install` / targeted `npm install next@16.1.1 react@19.2.3 react-dom@19.2.3`; installs were blocked by the environment (remote registry returned `403 Forbidden`). (Failed.)
- No unit or integration tests were added or modified; no automated test suite was executed as part of this polish pass.

All changes are presentation/copy/CTA-hierarchy only; no schema, backend, auth, routing, or new feature work was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee69783448328873c71853d690d6d)