### PR TITLE
Fix My Programs generation readiness, success copy, and BODY typography

### DIFF
--- a/app/components/FamilyProgramsWorkspace.tsx
+++ b/app/components/FamilyProgramsWorkspace.tsx
@@ -207,12 +207,20 @@ export default function FamilyProgramsWorkspace() {
   const hasPrograms = loadedProgramCount > 0;
   const hasVisiblePrograms = programs.length > 0;
   const hasGeneratedItems = generatedBlockCount > 0;
+  const hasLearnerSelected = Boolean(activeLearner?.id);
+  const hasProgramSegments = Boolean(selectedProgram?.segments.length);
   const hasMapping = Boolean(
     selectedProgram?.scheduleMapping?.calendarTemplateSlotId && selectedProgram?.scheduleMapping?.startDate,
   );
   const isFirstRun = !hasGeneratedItems && (!hasCalendarTemplate || !hasPrograms);
   const generationReady = Boolean(
-    selectedProgram && assignmentTemplateId && assignmentSlotId && assignmentStartDate && hasCalendarTemplate,
+    selectedProgram &&
+      hasLearnerSelected &&
+      hasProgramSegments &&
+      assignmentTemplateId &&
+      assignmentSlotId &&
+      assignmentStartDate &&
+      hasCalendarTemplate,
   );
 
   const selectedSegment =
@@ -363,7 +371,7 @@ export default function FamilyProgramsWorkspace() {
       setGeneratedBlockCount((current) => current + generated.length);
       setLastGeneratedCount(generated.length);
       setShowGenerationSuccess(true);
-      setStatus(`${generated.length} live planning block${generated.length === 1 ? "" : "s"} generated into My Plan.`);
+      setStatus("Program generated into My Plan. Open My Plan to adjust the week.");
     } catch {
       setError(friendlyProgramsMessage("generate"));
     } finally {

--- a/app/components/programs/ProgramOverviewComponents.tsx
+++ b/app/components/programs/ProgramOverviewComponents.tsx
@@ -11,7 +11,7 @@ import type {
 export const LABEL = "text-[12px] font-semibold uppercase tracking-[0.18em] text-slate-500";
 export const H2 = "text-[18px] font-bold tracking-tight text-slate-950";
 export const H3 = "text-[15px] font-semibold text-slate-950";
-export const BODY = "text-[14px] leading-6 text-slate-600";
+export const BODY = "text-[14px] leading-5 text-slate-600";
 export const META = "text-[13px] leading-5 text-slate-500";
 export const INPUT =
   "w-full rounded-[14px] border border-slate-200 bg-white px-4 py-3 text-[14px] text-slate-900 outline-none transition focus:border-blue-200 focus:ring-4 focus:ring-blue-100";
@@ -152,6 +152,7 @@ export function ProgramGenerationSuccessBanner({
   onOpenPlan: () => void;
   onStayHere: () => void;
 }) {
+  void count;
   return (
     <section className="grid gap-4 rounded-[24px] border border-emerald-200 bg-emerald-50/90 p-5 shadow-[0_10px_28px_rgba(15,23,42,0.04)]">
       <div className="grid gap-1.5">
@@ -160,7 +161,7 @@ export function ProgramGenerationSuccessBanner({
         </div>
         <h2 className={H2}>Your program is now live in your weekly plan</h2>
         <p className={BODY}>
-          {count} live planning block{count === 1 ? "" : "s"} {count === 1 ? "is" : "are"} ready in My Plan and can be adjusted there at any time.
+          Program generated into My Plan. Open My Plan to adjust the week.
         </p>
         <p className={META}>Open My Plan to view the generated week, or stay here and keep refining the sequence.</p>
       </div>


### PR DESCRIPTION
### Motivation
- Restore the missing My Programs "polish" so generation is only enabled when all required pieces are present, and make the generation success copy and BODY typography canonical.

### Description
- Tightened readiness logic in `app/components/FamilyProgramsWorkspace.tsx` by adding `hasLearnerSelected` and `hasProgramSegments` and requiring both in the `generationReady` condition so generation is disabled unless a program, learner, and at least one segment are selected alongside template/slot/date.
- Replaced dynamic generation success text with the exact canonical sentence `"Program generated into My Plan. Open My Plan to adjust the week."` in the `handleGenerate` status and in the `ProgramGenerationSuccessBanner` body in `app/components/programs/ProgramOverviewComponents.tsx` and silenced the unused `count` value there.
- Adjusted the `BODY` typography token in `app/components/programs/ProgramOverviewComponents.tsx` from `leading-6` to `leading-5` to match the requested typographic change.

### Testing
- Ran `npm run build` to validate the change, but the build did not run to completion in this environment because `next` is not installed (`sh: 1: next: not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef052d444832887f966f1bc5852ff)