### PR TITLE
Fix My Programs generation readiness, success copy, and body leading

### DIFF
--- a/app/components/FamilyProgramsWorkspace.tsx
+++ b/app/components/FamilyProgramsWorkspace.tsx
@@ -210,9 +210,17 @@ export default function FamilyProgramsWorkspace() {
   const hasMapping = Boolean(
     selectedProgram?.scheduleMapping?.calendarTemplateSlotId && selectedProgram?.scheduleMapping?.startDate,
   );
+  const hasLearnerSelected = Boolean(activeLearner?.id);
+  const hasProgramSegments = Boolean(selectedProgram?.segments.length);
   const isFirstRun = !hasGeneratedItems && (!hasCalendarTemplate || !hasPrograms);
   const generationReady = Boolean(
-    selectedProgram && assignmentTemplateId && assignmentSlotId && assignmentStartDate && hasCalendarTemplate,
+    selectedProgram &&
+      hasLearnerSelected &&
+      hasProgramSegments &&
+      assignmentTemplateId &&
+      assignmentSlotId &&
+      assignmentStartDate &&
+      hasCalendarTemplate,
   );
 
   const selectedSegment =
@@ -363,7 +371,7 @@ export default function FamilyProgramsWorkspace() {
       setGeneratedBlockCount((current) => current + generated.length);
       setLastGeneratedCount(generated.length);
       setShowGenerationSuccess(true);
-      setStatus(`${generated.length} live planning block${generated.length === 1 ? "" : "s"} generated into My Plan.`);
+      setStatus("Program generated into My Plan. Open My Plan to adjust the week.");
     } catch {
       setError(friendlyProgramsMessage("generate"));
     } finally {

--- a/app/components/programs/ProgramOverviewComponents.tsx
+++ b/app/components/programs/ProgramOverviewComponents.tsx
@@ -11,7 +11,7 @@ import type {
 export const LABEL = "text-[12px] font-semibold uppercase tracking-[0.18em] text-slate-500";
 export const H2 = "text-[18px] font-bold tracking-tight text-slate-950";
 export const H3 = "text-[15px] font-semibold text-slate-950";
-export const BODY = "text-[14px] leading-6 text-slate-600";
+export const BODY = "text-[14px] leading-5 text-slate-600";
 export const META = "text-[13px] leading-5 text-slate-500";
 export const INPUT =
   "w-full rounded-[14px] border border-slate-200 bg-white px-4 py-3 text-[14px] text-slate-900 outline-none transition focus:border-blue-200 focus:ring-4 focus:ring-blue-100";
@@ -144,7 +144,7 @@ export function ProgramsGuidedSetupBanner({
 }
 
 export function ProgramGenerationSuccessBanner({
-  count,
+  count: _count,
   onOpenPlan,
   onStayHere,
 }: {
@@ -158,11 +158,7 @@ export function ProgramGenerationSuccessBanner({
         <div className="text-[12px] font-semibold uppercase tracking-[0.18em] text-emerald-700">
           Generation complete
         </div>
-        <h2 className={H2}>Your program is now live in your weekly plan</h2>
-        <p className={BODY}>
-          {count} live planning block{count === 1 ? "" : "s"} {count === 1 ? "is" : "are"} ready in My Plan and can be adjusted there at any time.
-        </p>
-        <p className={META}>Open My Plan to view the generated week, or stay here and keep refining the sequence.</p>
+        <h2 className={H2}>Program generated into My Plan. Open My Plan to adjust the week.</h2>
       </div>
       <div className="flex flex-wrap gap-3">
         <button


### PR DESCRIPTION
### Motivation
- Restore the missing My Programs polish by making generation availability stricter (require learner and at least one segment), enforce the canonical generation success copy, and apply the requested local typography tweak.

### Description
- Require both `hasLearnerSelected` and `hasProgramSegments` in `generationReady` so Generate is disabled until a learner is selected and the selected program has at least one segment (`app/components/FamilyProgramsWorkspace.tsx`).
- Replace the dynamic generation success copy with the exact canonical text `"Program generated into My Plan. Open My Plan to adjust the week."` in the post-generate status and success banner headline (`app/components/FamilyProgramsWorkspace.tsx` and `app/components/programs/ProgramOverviewComponents.tsx`).
- Adjust the local `BODY` typography utility from `leading-6` to `leading-5` in `ProgramOverviewComponents.tsx` without any global refactor.

### Testing
- Ran `npm run build`, which could not complete in this environment because the `next` binary is not available (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef048c98c8328811ce1dfb5801108)