### PR TITLE
Update login copy to MyLearna branding and soften sign-in heading

### DIFF
--- a/app/components/AuthModal.tsx
+++ b/app/components/AuthModal.tsx
@@ -71,7 +71,7 @@ export default function AuthModal({ open, onClose, returnPath }: AuthModalProps)
               color: "#475569",
             }}
           >
-            EduDecks now uses one password-first login flow. Continue there, then come back to finish what you were doing.
+            MyLearna now uses one password-first login flow. Continue there, then come back to finish what you were doing.
           </div>
         </div>
 

--- a/app/components/EmailAuthPage.tsx
+++ b/app/components/EmailAuthPage.tsx
@@ -276,17 +276,18 @@ function EmailAuthPageContent() {
 
   return (
     <PublicSiteShell
-      eyebrow="Sign in to EduDecks"
-      heroTitle="Password-first family sign-in"
-      heroText="Use your email and password to get back into the family workspace quickly and repeatably."
+      title="MyLearna"
+      eyebrow="Sign in to MyLearna"
+      heroTitle="Sign in to your family workspace"
+      heroText="Use your email and password to return to your family workspace."
       heroBadges={[]}
       primaryCta={null}
       secondaryCta={null}
       headerAction={{ label: "Home", href: "/" }}
       footerPrimaryCta={{ label: "Back to login", href: "/login" }}
-      footerSecondaryCta={{ label: "See how EduDecks works", href: "/get-started" }}
+      footerSecondaryCta={{ label: "See how MyLearna works", href: "/get-started" }}
       asideTitle="Simple auth"
-      asideText="EduDecks now uses a single password-first login flow for everyday family use and repeated testing."
+      asideText="MyLearna uses a single password-first login flow for everyday family use and repeated testing."
       showWorkflowStrip={false}
     >
       <section
@@ -333,7 +334,7 @@ function EmailAuthPageContent() {
               maxWidth: 720,
             }}
           >
-            Sign in with your EduDecks email and password. If you need to set a new password, use the reset link below.
+            Sign in with your MyLearna email and password. If you need to set a new password, use the reset link below.
           </div>
 
           <form
@@ -535,7 +536,7 @@ function EmailAuthPageContent() {
           </div>
 
           <Link href="/get-started" style={secondaryButtonStyle()}>
-            See how EduDecks works
+            See how MyLearna works
           </Link>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Replace visible EduDecks wording on the login/auth entry page with MyLearna so branding is consistent for end users. 
- Make the login hero heading and helper copy calmer and more parent-friendly while keeping the password-first meaning. 
- Limit changes to copy only and preserve all authentication behavior and routes.

### Description
- Updated `app/components/EmailAuthPage.tsx` to set `title="MyLearna"`, change `eyebrow` to `"Sign in to MyLearna"`, change `heroTitle` to `"Sign in to your family workspace"`, and update `heroText` to a warmer helper (`"Use your email and password to return to your family workspace."`).
- Replaced visible in-page references and CTAs: `"Sign in with your EduDecks email..."` → `"Sign in with your MyLearna email..."`, and `"See how EduDecks works"` → `"See how MyLearna works"` (footer/in-page link); also updated the aside text to refer to MyLearna.
- Updated `app/components/AuthModal.tsx` helper text from `EduDecks now uses...` → `MyLearna now uses...`.
- No authentication handlers, password-reset flow, session/callback code, routes, navigation, backend/schema, or UI layout/design were changed.

### Testing
- Searched the modified login-related files for old-brand terms with `rg -n "EduDecks|edudecks"` against `app/login/page.tsx`, `app/components/EmailAuthPage.tsx`, `app/components/AuthModal.tsx`, `app/components/AuthRouteGuard.tsx`, and `app/components/AuthUserProvider.tsx`, and confirmed the login-related files no longer contain visible `EduDecks`/`edudecks` references.
- Ran a full search used during work: `rg -n "EduDecks|edudecks|Password-first family sign-in|See how" app` to locate candidate strings to update.
- Attempted to run the requested build with `npm run build`, but the build failed in this environment with `sh: 1: next: not found`, so a production build was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0910087c8328a27cb9733727dfee)