### PR TITLE
Tighten My Day helper copy for scanability

### DIFF
--- a/app/components/MyDayWorkspace.tsx
+++ b/app/components/MyDayWorkspace.tsx
@@ -434,7 +434,7 @@ export default function MyDayWorkspace() {
       subtitle="My Day"
       heroTitle="Move through today's learning with clarity"
       heroText="See what is planned for today, keep the next useful step close, and capture evidence without leaving the flow."
-      workflowHelperText="My Calendar sets the weekly rhythm. My Programs shapes the longer sequence. My Plan edits the live week. Capture runs the day. Outputs groups curriculum, portfolio, reports, and progress, while Community stays separate from the core workflow."
+      workflowHelperText="Set your rhythm in My Calendar. Build longer sequences in My Programs. Shape this week in My Plan. Capture today's learning here."
       heroAsideTitle="Today at a glance"
       heroAsideText={heroAsideText}
     >


### PR DESCRIPTION
### Motivation
- Make the My Day workflow helper paragraph easier to scan by breaking it into short, direct sentences while preserving the existing workflow meaning and tone.
- Verify that the My Day surface is not unintentionally right-shifted and only change layout if clearly incorrect.

### Description
- Replaced the `workflowHelperText` passed into `FamilyTopNavShell` in `app/components/MyDayWorkspace.tsx` with a tighter four-sentence variant: `"Set your rhythm in My Calendar. Build longer sequences in My Programs. Shape this week in My Plan. Capture today's learning here."`.
- Only this string in `app/components/MyDayWorkspace.tsx` was changed and no UI behavior, routing, data, or readiness-state logic was modified.
- Layout was reviewed in `app/components/FamilyTopNavShell.tsx` and left unchanged because content centering is already handled via `mx-auto` and `max-w-[1440px]`.

### Testing
- Ran the automated build with `npm run build`; it failed in this environment because `next` is not available on PATH (`sh: 1: next: not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0e23c1fc8328864c81ab604d3322)