### PR TITLE
Fix dead Outputs control in authenticated top nav

### DIFF
--- a/app/components/FamilyTopNavShell.tsx
+++ b/app/components/FamilyTopNavShell.tsx
@@ -259,27 +259,29 @@ export default function FamilyTopNavShell({
               <BrandHomeLink href="/my-day" />
             </div>
 
-            <nav className="flex min-w-0 items-center gap-1.5 overflow-x-auto rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
-              {PRIMARY_NAV.map((item) => {
-                const active = normalizedPath === item.href;
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={cx(
-                      "inline-flex items-center rounded-full px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] transition duration-150",
-                      active
-                        ? "bg-white text-slate-950 shadow-[0_8px_22px_rgba(15,23,42,0.08)] ring-1 ring-slate-200"
-                        : "text-slate-500 hover:bg-white/90 hover:text-slate-900",
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                );
-              })}
+            <div className="min-w-0 overflow-x-auto">
+              <nav className="flex min-w-max items-center gap-1.5 rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
+                {PRIMARY_NAV.map((item) => {
+                  const active = normalizedPath === item.href;
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={cx(
+                        "inline-flex items-center rounded-full px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] transition duration-150",
+                        active
+                          ? "bg-white text-slate-950 shadow-[0_8px_22px_rgba(15,23,42,0.08)] ring-1 ring-slate-200"
+                          : "text-slate-500 hover:bg-white/90 hover:text-slate-900",
+                      )}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
 
-              <OutputsDropdown pathname={pathname} />
-            </nav>
+                <OutputsDropdown pathname={pathname} />
+              </nav>
+            </div>
           </div>
 
           <div className="flex items-center justify-between gap-3 lg:justify-end">
@@ -464,4 +466,3 @@ export function FamilyCommandLayer({
     </section>
   );
 }
-


### PR DESCRIPTION
### Motivation
- The Outputs control in the authenticated top navigation appeared clickable but the dropdown was clipped and did nothing, so the interaction needed to be restored without redesigning navigation.
- The change implements the existing dropdown behavior (Option A) so Outputs opens a real menu that routes to existing pages.

### Description
- Updated `app/components/FamilyTopNavShell.tsx` to wrap the pill group in a `div` with `overflow-x-auto` and change the inner `nav` to use `min-w-max`, preventing the dropdown from being clipped.
- Kept the existing `OutputsDropdown` component and its menu items (`/curriculum`, `/my-portfolio`, `/my-reports`, `/my-progress`) intact and unchanged.
- No routing, schema, auth, page additions, or visual redesigns were made outside the layout wrapper adjustment.

### Testing
- Ran `npm run build`, which failed in this environment with `sh: 1: next: not found`, so a full build verification could not be completed here.
- The change is limited to `app/components/FamilyTopNavShell.tsx` and was committed successfully, ready for CI/build verification in an environment with `next` installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1315abd88328821bd5bf35c2061d)