### PR TITLE
Fix My Calendar action integrity and save-state messaging

### DIFF
--- a/app/components/FamilyCalendarTemplateWorkspace.tsx
+++ b/app/components/FamilyCalendarTemplateWorkspace.tsx
@@ -27,9 +27,9 @@ function makeId(prefix: string) {
 
 function friendlyCalendarMessage(kind: "load" | "save") {
   if (kind === "load") {
-    return "My Calendar is still settling. Your weekly rhythm is safe, and you can try again in a moment.";
+    return "We couldn't load your calendar template right now. Please try again.";
   }
-  return "Your weekly rhythm could not be saved just yet. Keep shaping it here, then save again in a moment.";
+  return "We couldn't save your calendar template right now. Please try again.";
 }
 
 export default function FamilyCalendarTemplateWorkspace() {
@@ -121,12 +121,12 @@ export default function FamilyCalendarTemplateWorkspace() {
     setError("");
   }
 
-  function handleAddSlot() {
+  function handleAddSlot(dayOfWeek = 1) {
     if (!selectedTemplate) return;
     const nextSlot: TemplateSlot = {
       id: makeId("slot"),
       templateId: selectedTemplate.id,
-      dayOfWeek: 1,
+      dayOfWeek,
       startTime: "",
       endTime: "",
       subjectId: "",
@@ -255,12 +255,13 @@ export default function FamilyCalendarTemplateWorkspace() {
               slots={selectedTemplate?.slots || []}
               selectedSlotId={selectedSlotId}
               onSelectSlot={setSelectedSlotId}
+              onAddFirstSlot={handleAddSlot}
             />
             <CalendarTemplateSlotEditor
               slot={selectedSlot}
               onChange={handleSlotChange}
               onDelete={handleDeleteSlot}
-              onAddNew={handleAddSlot}
+              onAddNew={() => handleAddSlot()}
             />
           </div>
         )}
@@ -281,7 +282,7 @@ export default function FamilyCalendarTemplateWorkspace() {
           <button
             type="button"
             onClick={() => void handleSave()}
-            disabled={saving || !selectedTemplate}
+            disabled={saving || !selectedTemplate || !templateReady}
             className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-[14px] font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
           >
             {saving ? "Saving..." : returnTo ? "Save template and continue" : "Save template"}

--- a/app/components/calendar/CalendarTemplateOverviewComponents.tsx
+++ b/app/components/calendar/CalendarTemplateOverviewComponents.tsx
@@ -77,10 +77,12 @@ export function CalendarTemplateGrid({
   slots,
   selectedSlotId,
   onSelectSlot,
+  onAddFirstSlot,
 }: {
   slots: TemplateSlot[];
   selectedSlotId?: string | null;
   onSelectSlot: (slotId: string) => void;
+  onAddFirstSlot: (dayOfWeek: number) => void;
 }) {
   const hasSlots = slots.length > 0;
 
@@ -130,9 +132,13 @@ export function CalendarTemplateGrid({
                     );
                   })
                 ) : (
-                  <div className="rounded-[16px] border border-dashed border-slate-200 bg-white px-3 py-5 text-center text-[13px] font-medium text-slate-500">
+                  <button
+                    type="button"
+                    onClick={() => onAddFirstSlot(day.value)}
+                    className="rounded-[16px] border border-dashed border-slate-200 bg-white px-3 py-5 text-center text-[13px] font-medium text-slate-500 transition hover:border-slate-300 hover:bg-slate-50"
+                  >
                     Add the first slot
-                  </div>
+                  </button>
                 )}
               </div>
             </article>


### PR DESCRIPTION
### Motivation
- Ensure all visible actions on `/my-calendar` are real and functional by removing no-op placeholders and making save state explicit and understandable.
- Make the weekday "Add the first slot" interaction open the slot editor for that specific day so users can immediately edit newly created slots.

### Description
- Converted the weekday placeholder into a clickable button and added an `onAddFirstSlot` callback to `CalendarTemplateGrid` so the weekday context is passed when creating a new slot. (files: `app/components/calendar/CalendarTemplateOverviewComponents.tsx`, `app/components/FamilyCalendarTemplateWorkspace.tsx`).
- Implemented `handleAddSlot(dayOfWeek = 1)` in `FamilyCalendarTemplateWorkspace` and wired it to both the grid weekday buttons and the right-panel "Add slot" action so new slots are created and selected in the editor. (file: `app/components/FamilyCalendarTemplateWorkspace.tsx`).
- Prevented the Save action from being clickable until the template is valid by disabling the save button when no slots exist (`templateReady`). (file: `app/components/FamilyCalendarTemplateWorkspace.tsx`).
- Replaced vague load/save fallback copy with clearer, direct messaging to reduce user confusion. (file: `app/components/FamilyCalendarTemplateWorkspace.tsx`).

### Testing
- Ran `npm run build` to verify the app build, but it failed in this environment with `sh: 1: next: not found`, so a full build could not be completed. (failed)
- Ran `npm ci` to reproduce a clean install, which failed due to lockfile/dependency sync issues in this environment, preventing a clean CI install. (failed)
- Ran `npm install` to attempt to restore dependencies, which started but the execution environment did not provide a working `next` binary for `next build`, so build verification remained blocked. (attempted)
- No automated unit or integration tests were executed successfully here because the environment prevented a full install/build; changes were validated by static review of the updated components and local wiring of interactions in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1562b91c83289af6441ffc20bb5c)