### PR TITLE
Fix My Calendar action integrity and save-state messaging

### DIFF
--- a/app/components/FamilyCalendarTemplateWorkspace.tsx
+++ b/app/components/FamilyCalendarTemplateWorkspace.tsx
@@ -27,9 +27,9 @@ function makeId(prefix: string) {
 
 function friendlyCalendarMessage(kind: "load" | "save") {
   if (kind === "load") {
-    return "My Calendar is still settling. Your weekly rhythm is safe, and you can try again in a moment.";
+    return "We couldn't load your calendar template just now. Your weekly rhythm is safe—please try again in a moment.";
   }
-  return "Your weekly rhythm could not be saved just yet. Keep shaping it here, then save again in a moment.";
+  return "We couldn't save your calendar template yet. Please try saving again in a moment.";
 }
 
 export default function FamilyCalendarTemplateWorkspace() {
@@ -121,12 +121,12 @@ export default function FamilyCalendarTemplateWorkspace() {
     setError("");
   }
 
-  function handleAddSlot() {
+  function handleAddSlot(dayOfWeek = 1) {
     if (!selectedTemplate) return;
     const nextSlot: TemplateSlot = {
       id: makeId("slot"),
       templateId: selectedTemplate.id,
-      dayOfWeek: 1,
+      dayOfWeek,
       startTime: "",
       endTime: "",
       subjectId: "",
@@ -255,6 +255,7 @@ export default function FamilyCalendarTemplateWorkspace() {
               slots={selectedTemplate?.slots || []}
               selectedSlotId={selectedSlotId}
               onSelectSlot={setSelectedSlotId}
+              onAddFirstSlot={handleAddSlot}
             />
             <CalendarTemplateSlotEditor
               slot={selectedSlot}
@@ -272,7 +273,7 @@ export default function FamilyCalendarTemplateWorkspace() {
               {error ||
                 status ||
                 (!templateReady
-                  ? "Add at least one slot to make this weekly rhythm reusable in My Programs."
+                  ? "Add at least one slot before saving your template."
                   : returnTo
                     ? "Your weekly rhythm is ready. Save and continue back to My Programs."
                     : "Your weekly rhythm is ready to use in My Programs and My Plan.")}
@@ -281,7 +282,7 @@ export default function FamilyCalendarTemplateWorkspace() {
           <button
             type="button"
             onClick={() => void handleSave()}
-            disabled={saving || !selectedTemplate}
+            disabled={saving || !selectedTemplate || !templateReady}
             className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-[14px] font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
           >
             {saving ? "Saving..." : returnTo ? "Save template and continue" : "Save template"}

--- a/app/components/calendar/CalendarTemplateOverviewComponents.tsx
+++ b/app/components/calendar/CalendarTemplateOverviewComponents.tsx
@@ -77,10 +77,12 @@ export function CalendarTemplateGrid({
   slots,
   selectedSlotId,
   onSelectSlot,
+  onAddFirstSlot,
 }: {
   slots: TemplateSlot[];
   selectedSlotId?: string | null;
   onSelectSlot: (slotId: string) => void;
+  onAddFirstSlot: (dayOfWeek: number) => void;
 }) {
   const hasSlots = slots.length > 0;
 
@@ -130,9 +132,13 @@ export function CalendarTemplateGrid({
                     );
                   })
                 ) : (
-                  <div className="rounded-[16px] border border-dashed border-slate-200 bg-white px-3 py-5 text-center text-[13px] font-medium text-slate-500">
+                  <button
+                    type="button"
+                    onClick={() => onAddFirstSlot(day.value)}
+                    className="rounded-[16px] border border-dashed border-slate-200 bg-white px-3 py-5 text-center text-[13px] font-medium text-slate-500 transition hover:border-slate-300 hover:bg-slate-50"
+                  >
                     Add the first slot
-                  </div>
+                  </button>
                 )}
               </div>
             </article>


### PR DESCRIPTION
### Motivation
- Ensure every visible control on My Calendar is a real, functioning action (no no-op buttons) so users can create and edit slots reliably.
- Make the weekday “Add the first slot” affordance open the real slot editor for that day and ensure save state is truthful and clear.
- Improve load/save fallback copy to be clearer and calm for parent-facing users while preserving layout and behavior.

### Description
- Converted the per-weekday “Add the first slot” placeholder into a real button and added an `onAddFirstSlot(dayOfWeek)` callback in `app/components/calendar/CalendarTemplateOverviewComponents.tsx` so clicking a weekday creates a slot for that day. 
- Made slot creation day-aware by changing `handleAddSlot` to accept an optional `dayOfWeek` and wired `onAddFirstSlot` to `handleAddSlot` in `app/components/FamilyCalendarTemplateWorkspace.tsx` so newly created slots open in the editor with the correct day selected. 
- Disabled the save control until the template is valid (`!templateReady`) and updated the helper copy to: “Add at least one slot before saving your template.” in `app/components/FamilyCalendarTemplateWorkspace.tsx`. 
- Rewrote ambiguous load/save fallback messages to friendlier, clearer wording in `app/components/FamilyCalendarTemplateWorkspace.tsx`.

### Testing
- Attempted to run the production build with `npm run build`, but the command failed in this environment because the `next` binary is not available (`sh: 1: next: not found`).
- Changes were smoke-validated by inspecting the updated components and confirming proper prop wiring and state updates (no automated UI tests executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef197f4b888328a679585fdece6841)