### PR TITLE
Replace visible “Preview” placeholders and anchor Continue planning to weekly planner

### DIFF
--- a/app/components/FamilyPlanWorkspace.tsx
+++ b/app/components/FamilyPlanWorkspace.tsx
@@ -554,7 +554,7 @@ export default function FamilyPlanWorkspace() {
                 ? "Ready to shape"
                 : "Needs shaping"
             : hasActiveLearner
-              ? "Preview"
+              ? "Needs setup"
               : "Choose learner",
       note:
         planState === "live"
@@ -573,7 +573,7 @@ export default function FamilyPlanWorkspace() {
           : planState === "live"
             ? String(totalWeekBlocks)
             : hasActiveLearner
-              ? "Preview"
+              ? "No blocks yet"
               : "0",
       note:
         planState === "live"
@@ -631,7 +631,7 @@ export default function FamilyPlanWorkspace() {
   const healthCards: PlanMetricCardProps[] = [
     {
       label: "Active blocks",
-      value: planState === "loading" ? "" : planState === "live" ? String(totalWeekBlocks) : hasActiveLearner ? "Preview" : "0",
+      value: planState === "loading" ? "" : planState === "live" ? String(totalWeekBlocks) : hasActiveLearner ? "No blocks yet" : "0",
       note:
         planState === "live"
           ? `${totalWeekBlocks} block${totalWeekBlocks === 1 ? "" : "s"} across this week`
@@ -643,7 +643,7 @@ export default function FamilyPlanWorkspace() {
     },
     {
       label: "Ready now",
-      value: planState === "loading" ? "" : planState === "live" ? String(completedActions) : hasActiveLearner ? "Preview" : "0",
+      value: planState === "loading" ? "" : planState === "live" ? String(completedActions) : hasActiveLearner ? "Not started" : "0",
       note:
         planState === "live"
           ? `${completedActions} action${completedActions === 1 ? "" : "s"} already settled`
@@ -655,7 +655,7 @@ export default function FamilyPlanWorkspace() {
     },
     {
       label: "Needs shaping",
-      value: planState === "loading" ? "" : planState === "live" ? String(openDays) : hasActiveLearner ? "Preview" : "0",
+      value: planState === "loading" ? "" : planState === "live" ? String(openDays) : hasActiveLearner ? "Nothing scheduled yet" : "0",
       note:
         planState === "live"
           ? `${openDays} day${openDays === 1 ? "" : "s"} still open this week`
@@ -709,7 +709,7 @@ export default function FamilyPlanWorkspace() {
           : {
               title: `Start ${activeLearnerName}'s first visual plan`,
               note: "Use one small learning block to make the week feel settled. My Calendar sets the rhythm behind it, but My Plan is the right place to start the live week.",
-              ctaHref: "/my-plan",
+              ctaHref: "#weekly-planner",
               ctaLabel: "Continue planning",
               state: hasActiveLearner ? "placeholder" as HomeSurfaceState : "empty" as HomeSurfaceState,
             };

--- a/app/components/plan/PlanOverviewComponents.tsx
+++ b/app/components/plan/PlanOverviewComponents.tsx
@@ -719,6 +719,7 @@ export function VisualWeeklyPlanner({
 }) {
   return (
     <section
+      id="weekly-planner"
       className={cx(
         "grid gap-4 rounded-[26px] border px-6 py-6 shadow-[0_12px_30px_rgba(15,23,42,0.05)]",
         surfaceTone(state),


### PR DESCRIPTION
### Motivation
- Remove misleading placeholder copy that presented as actionable data on the My Plan surface and ensure all visible CTAs perform real behavior. 
- Ensure the “Continue planning” CTA has a meaningful destination (scroll/focus) rather than looping to the same route.

### Description
- Replaced visible metric fallback values that showed `"Preview"` with truthful state text (`"Needs setup"`, `"No blocks yet"`, `"Not started"`, `"Nothing scheduled yet"`) in `app/components/FamilyPlanWorkspace.tsx`.
- Updated the Next Move `Continue planning` CTA to target an in-page anchor (`#weekly-planner`) instead of re-linking to `/my-plan` in `app/components/FamilyPlanWorkspace.tsx`.
- Added `id="weekly-planner"` to the weekly planner container in `app/components/plan/PlanOverviewComponents.tsx` so the CTA has a concrete in-page destination.
- No behavioral reshapes of flows, no schema/backend changes, and no changes to global navigation beyond the anchor and copy adjustments.

### Testing
- Searched the codebase for `Preview|demo|placeholder` to confirm the visible placeholder-like strings were addressed in the modified components.
- Verified the modified files and inspected the resulting diffs to confirm only the intended copy/anchor changes were applied.
- Ran `npm run build` in this environment and it failed due to a missing `next` binary (`sh: 1: next: not found`), so a full production build could not be completed here.
- Manual audit of the listed My Plan actions shows quick actions and planner controls remain wired to real handlers or routes; the `Continue planning` CTA now points to the planner section anchor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef248883e483288feca1d7ecf8fee1)