### PR TITLE
Calm linked-plan empty state and preserve truthful capture interactions

### DIFF
--- a/app/components/FamilyCaptureWorkspace.tsx
+++ b/app/components/FamilyCaptureWorkspace.tsx
@@ -59,7 +59,7 @@ type LinkedBlockOption = FamilyCalendarBlockEntry & {
 
 function friendlyCaptureMessage(kind: "load" | "save" | "setup") {
   if (kind === "load") {
-    return "Linked plan blocks are still getting ready. You can keep the capture focused on the learning moment.";
+    return "We could not load linked plan blocks just now. You can still capture this learning moment and try again shortly.";
   }
   if (kind === "setup") {
     return "Choose a synced learner workspace before capturing evidence.";
@@ -95,6 +95,7 @@ export default function FamilyCaptureWorkspace() {
   const [submitting, setSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [linkedBlocksError, setLinkedBlocksError] = useState("");
 
   const hasLearners = workspace.learners.length > 0;
   const hasActiveLearner = Boolean(activeLearner);
@@ -126,6 +127,7 @@ export default function FamilyCaptureWorkspace() {
         if (mounted) {
           setLinkedBlocks([]);
           setLoadingBlocks(false);
+          setLinkedBlocksError("");
         }
         return;
       }
@@ -158,9 +160,10 @@ export default function FamilyCaptureWorkspace() {
           .sort((a, b) => a.date.localeCompare(b.date));
 
         setLinkedBlocks(options);
+        setLinkedBlocksError("");
       } catch {
         if (!mounted) return;
-        setErrorMessage(friendlyCaptureMessage("load"));
+        setLinkedBlocksError(friendlyCaptureMessage("load"));
       } finally {
         if (mounted) setLoadingBlocks(false);
       }
@@ -338,6 +341,19 @@ export default function FamilyCaptureWorkspace() {
                   ))}
                 </CaptureSelect>
                 <div className={META_TEXT}>{primaryLinkedSummary}</div>
+                {loadingBlocks ? (
+                  <div className={META_TEXT}>Loading linked plan blocks…</div>
+                ) : null}
+                {!loadingBlocks && !linkedBlocksError && canonicalReady && hasActiveLearner && linkedBlocks.length === 0 ? (
+                  <div className="rounded-[14px] border border-blue-200 bg-blue-50 px-3 py-2 text-[13px] leading-5 text-blue-700">
+                    No linked plan blocks yet. You can still capture this learning moment now.
+                  </div>
+                ) : null}
+                {linkedBlocksError ? (
+                  <div className="rounded-[14px] border border-rose-200 bg-rose-50 px-3 py-2 text-[13px] leading-5 text-rose-700">
+                    {linkedBlocksError}
+                  </div>
+                ) : null}
               </div>
 
               <div className="grid gap-2">


### PR DESCRIPTION
### Motivation
- Avoid alarming or fake UI on the Capture page when there are simply no linked plan blocks available.
- Ensure every visible Capture action is real, wired, and truthful (no dead buttons or misleading warnings). 
- Keep existing capture flows and UX intact while making the linked-plan unavailable state calmer and clearer.

### Description
- Updated the linked-plan load failure copy and replaced the previous “still getting ready” phrasing with a parent-friendly message returned by `friendlyCaptureMessage("load")` in `FamilyCaptureWorkspace`.
- Added `linkedBlocksError` state and UI branches to `app/components/FamilyCaptureWorkspace.tsx` to explicitly show: a loading line while blocks are loading, a calm informational blue notice when there are no linked blocks, and a red-toned error only when loading actually fails.
- Preserved all existing capture interactions (learner selection, date input, linked-block select, evidence submit, add/edit curriculum, learning area and reflection inputs) and did not change backend, schema, routing, or global navigation.

### Testing
- Searched capture-related code for problematic phrases using ripgrep: looked for `still getting ready`, `failed`, `error`, `placeholder`, and `demo` (search completed). 
- Attempted project build with `npm run build`; the command failed in this environment with `sh: 1: next: not found`, so a full production build could not be verified here.
- No automated unit test suite was run in this environment; changes are limited to `app/components/FamilyCaptureWorkspace.tsx` and are UI/state-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef27cd33a0832889197c60377ff554)