### PR TITLE
Fix Outputs dropdown clipping in family top nav

### DIFF
--- a/app/components/FamilyTopNavShell.tsx
+++ b/app/components/FamilyTopNavShell.tsx
@@ -259,26 +259,30 @@ export default function FamilyTopNavShell({
               <BrandHomeLink href="/my-day" />
             </div>
 
-            <nav className="flex min-w-0 items-center gap-1.5 overflow-x-auto rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
-              {PRIMARY_NAV.map((item) => {
-                const active = normalizedPath === item.href;
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={cx(
-                      "inline-flex items-center rounded-full px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] transition duration-150",
-                      active
-                        ? "bg-white text-slate-950 shadow-[0_8px_22px_rgba(15,23,42,0.08)] ring-1 ring-slate-200"
-                        : "text-slate-500 hover:bg-white/90 hover:text-slate-900",
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                );
-              })}
+            <nav className="relative flex min-w-0 items-center gap-1.5 rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto">
+                {PRIMARY_NAV.map((item) => {
+                  const active = normalizedPath === item.href;
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={cx(
+                        "inline-flex items-center rounded-full px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] transition duration-150",
+                        active
+                          ? "bg-white text-slate-950 shadow-[0_8px_22px_rgba(15,23,42,0.08)] ring-1 ring-slate-200"
+                          : "text-slate-500 hover:bg-white/90 hover:text-slate-900",
+                      )}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </div>
 
-              <OutputsDropdown pathname={pathname} />
+              <div className="shrink-0">
+                <OutputsDropdown pathname={pathname} />
+              </div>
             </nav>
           </div>
 
@@ -464,4 +468,3 @@ export function FamilyCommandLayer({
     </section>
   );
 }
-


### PR DESCRIPTION
### Motivation
- The Outputs dropdown was being clipped by the horizontal-scrolling nav strip because it was rendered inside a container with `overflow-x-auto`, preventing the absolutely positioned menu from escaping the scrolling context.
- The change's intent is to make the dropdown visible without redesigning or changing existing behavior or routes.

### Description
- Removed the overflow from the outer nav and made the nav container `relative` so absolutely positioned children can escape clipping. 
- Moved the primary navigation links into an inner `div` that retains `overflow-x-auto` so horizontal scrolling still applies only to the links. 
- Rendered `OutputsDropdown` in a sibling `shrink-0` wrapper outside the overflowed area so its `absolute right-0 z-50` menu is no longer clipped. 
- File changed: `app/components/FamilyTopNavShell.tsx`.

### Testing
- Ran the project lint command `npm run lint -- app/components/FamilyTopNavShell.tsx`, which failed in this environment due to a missing local `eslint` package and could not validate the file automatically.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3ac87e5883288bf7e2248c58614b)