### PR TITLE
Fix Outputs dropdown clipping in family top nav

### DIFF
--- a/app/components/FamilyTopNavShell.tsx
+++ b/app/components/FamilyTopNavShell.tsx
@@ -259,24 +259,26 @@ export default function FamilyTopNavShell({
               <BrandHomeLink href="/my-day" />
             </div>
 
-            <nav className="flex min-w-0 items-center gap-1.5 overflow-x-auto rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
-              {PRIMARY_NAV.map((item) => {
-                const active = normalizedPath === item.href;
-                return (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={cx(
-                      "inline-flex items-center rounded-full px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] transition duration-150",
-                      active
-                        ? "bg-white text-slate-950 shadow-[0_8px_22px_rgba(15,23,42,0.08)] ring-1 ring-slate-200"
-                        : "text-slate-500 hover:bg-white/90 hover:text-slate-900",
-                    )}
-                  >
-                    {item.label}
-                  </Link>
-                );
-              })}
+            <nav className="flex min-w-0 items-center gap-1.5 rounded-full border border-slate-200/80 bg-slate-50/80 p-1">
+              <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto">
+                {PRIMARY_NAV.map((item) => {
+                  const active = normalizedPath === item.href;
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className={cx(
+                        "inline-flex items-center rounded-full px-4 py-2.5 text-[13px] font-semibold tracking-[-0.01em] transition duration-150",
+                        active
+                          ? "bg-white text-slate-950 shadow-[0_8px_22px_rgba(15,23,42,0.08)] ring-1 ring-slate-200"
+                          : "text-slate-500 hover:bg-white/90 hover:text-slate-900",
+                      )}
+                    >
+                      {item.label}
+                    </Link>
+                  );
+                })}
+              </div>
 
               <OutputsDropdown pathname={pathname} />
             </nav>
@@ -464,4 +466,3 @@ export function FamilyCommandLayer({
     </section>
   );
 }
-


### PR DESCRIPTION
### Motivation
- The Outputs dropdown was being clipped by the top-nav's horizontal-scroll container, preventing the menu from appearing above other content when opened.

### Description
- Moved `overflow-x-auto` off the outer nav pill into a new inner wrapper that contains only the primary nav links, and left `OutputsDropdown` as a sibling so its absolute-positioned menu can render outside the overflow context.
- Preserved existing dropdown anchoring and layering (`parent: relative`, menu: `absolute right-0` with `z-50`) and did not change routes, styles, or behavior beyond the overflow isolation.
- Files changed: `app/components/FamilyTopNavShell.tsx`.

### Testing
- Ran `npm run lint -- app/components/FamilyTopNavShell.tsx`, which failed in this environment because the `eslint` package dependencies are not installed; no other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3c023ddc83288b4a8d163e351756)