### PR TITLE
refactor: remove unused title logic from FamilyTopNavShell

### DIFF
--- a/app/components/FamilyTopNavShell.tsx
+++ b/app/components/FamilyTopNavShell.tsx
@@ -96,11 +96,6 @@ function routeSubtitle(pathname: string) {
   return "MyLearna";
 }
 
-function routeTitle(pathname: string) {
-  if (normalizeRoute(pathname)) return "";
-  return "MyLearna";
-}
-
 function routeHeroTitle(pathname: string, subtitle: string) {
   if (pathname === "/my-day" || pathname === "/home" || pathname === "/dashboard") {
     return "Move through today's learning with clarity";
@@ -254,7 +249,6 @@ function OutputsDropdown({ pathname }: { pathname: string }) {
 
 export default function FamilyTopNavShell({
   children,
-  title,
   subtitle,
   className,
   contentClassName,
@@ -274,7 +268,6 @@ export default function FamilyTopNavShell({
   const { user } = useAuthUser();
   const { workspace, activeLearner } = useFamilyWorkspace();
 
-  const resolvedTitle = title ?? routeTitle(pathname);
   const resolvedSubtitle = subtitle ?? routeSubtitle(pathname);
   const resolvedHeroTitle = heroTitle ?? routeHeroTitle(pathname, resolvedSubtitle);
   const resolvedHeroText = heroText ?? routeHeroText(pathname);


### PR DESCRIPTION
### Motivation
- Remove dead title-related logic from the component to simplify implementation and avoid unused variables.

### Description
- Deleted the `routeTitle` helper and removed the unused `title` destructured prop and `resolvedTitle` local from `app/components/FamilyTopNavShell.tsx` while keeping the public prop type unchanged.

### Testing
- Attempted `npm run lint` which failed due to a missing `eslint` package, and `npm test -- --watch=false` which failed because `vitest` is not installed, so no automated tests ran successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef42f14a488328a6ec633c1cf6e43f)