### PR TITLE
Improve Curriculum Map first-use copy, CTAs, and View button behavior

### DIFF
--- a/app/components/FamilyCurriculumMapWorkspace.tsx
+++ b/app/components/FamilyCurriculumMapWorkspace.tsx
@@ -69,7 +69,7 @@ function addDays(date: Date, days: number) {
 
 function recentLabel(value?: string | null) {
   const trimmed = safe(value);
-  if (!trimmed) return "Not yet";
+  if (!trimmed) return "Getting started";
   const parsed = new Date(trimmed);
   if (Number.isNaN(parsed.getTime())) return "Recently";
   const diffDays = Math.round((Date.now() - parsed.getTime()) / (1000 * 60 * 60 * 24));
@@ -251,9 +251,11 @@ export default function FamilyCurriculumMapWorkspace() {
             status,
             evidenceCount: signal?.evidenceCount ?? 0,
             lastTouchedAt: signal?.lastTouchedAt ? recentLabel(signal.lastTouchedAt) : null,
+            canView: Boolean(signal?.evidenceIds.length),
             viewHref: signal?.evidenceIds.length
               ? `/my-portfolio?evidence=${encodeURIComponent(signal.evidenceIds.join(","))}`
-              : `/my-portfolio?subject=${encodeURIComponent(subject.title)}`,
+              : undefined,
+            viewUnavailableReason: "Capture evidence for this outcome to open a detailed view.",
           };
         });
 
@@ -296,7 +298,7 @@ export default function FamilyCurriculumMapWorkspace() {
   const summaryCards = [
     {
       label: "Coverage confidence",
-      value: mapState === "loading" ? "" : mapState === "empty" ? "Not yet" : `${coverageConfidence}%`,
+      value: mapState === "loading" ? "" : mapState === "empty" ? "Ready to begin" : `${coverageConfidence}%`,
       note:
         mapState === "live"
           ? "Coverage becomes clearer as planning and evidence connect"
@@ -347,12 +349,12 @@ export default function FamilyCurriculumMapWorkspace() {
         }
       : mapState === "empty"
         ? {
-            title: `Tag the first curriculum signal for ${activeLearner?.label || "this learner"}`,
-            note: "Start by planning one tagged learning block or capturing one linked learning moment.",
-            href: "/my-plan",
-            cta: "Open My Plan",
-            state: "empty" as HomeSurfaceState,
-          }
+          title: `Tag the first curriculum signal for ${activeLearner?.label || "this learner"}`,
+          note: "Start by planning one tagged learning block or capturing one linked learning moment.",
+          href: "/capture",
+          cta: "Capture your first learning moment",
+          state: "empty" as HomeSurfaceState,
+        }
         : {
             title: `Strengthen ${selectedSubject?.title || "the next subject"} coverage`,
             note:
@@ -360,7 +362,7 @@ export default function FamilyCurriculumMapWorkspace() {
                 ? `Add one more capture to support ${selectedSubject?.strands.find((strand) => strand.counts.needs_support > 0)?.title || "the next strand"}.`
                 : `Plan one learning block for ${selectedSubject?.strands.find((strand) => strand.counts.not_started > 0)?.title || "the next strand"} this week.`,
             href: summaryCounts.needs_support > 0 ? "/capture" : "/my-plan",
-            cta: summaryCounts.needs_support > 0 ? "Capture Evidence" : "Open My Plan",
+            cta: summaryCounts.needs_support > 0 ? "Capture a learning moment" : "Open My Plan",
             state: mapState,
           };
 

--- a/app/components/curriculum/CurriculumMapOverviewComponents.tsx
+++ b/app/components/curriculum/CurriculumMapOverviewComponents.tsx
@@ -36,7 +36,9 @@ export type OutcomeCoverageView = {
   status: CoverageStatus;
   evidenceCount: number;
   lastTouchedAt?: string | null;
-  viewHref: string;
+  viewHref?: string;
+  canView: boolean;
+  viewUnavailableReason?: string;
 };
 
 export type StrandCoverageView = {
@@ -77,7 +79,7 @@ function coverageTone(status: CoverageStatus) {
     };
   }
   return {
-    label: "Not yet",
+    label: "Getting started",
     chip: "border-slate-200 bg-slate-50 text-slate-600",
     fill: "bg-slate-200",
   };
@@ -153,6 +155,19 @@ export function CoverageSummaryCards({
   );
 }
 
+function subjectProgressSummary(subject: SubjectCoverageTabData) {
+  if (!subject.counts.understood && !subject.counts.in_progress) {
+    return "No outcomes marked yet · Ready to begin";
+  }
+  const understoodLabel = subject.counts.understood
+    ? `${subject.counts.understood} understood`
+    : "No outcomes marked yet";
+  const inProgressLabel = subject.counts.in_progress
+    ? `${subject.counts.in_progress} in progress`
+    : "Ready to begin";
+  return `${understoodLabel} / ${inProgressLabel}`;
+}
+
 export function SubjectCoverageTabs({
   subjects,
   selectedSubjectId,
@@ -194,9 +209,7 @@ export function SubjectCoverageTabs({
                 )}
               >
                 <span className={CARD_TITLE}>{subject.title}</span>
-                <span className={META_TEXT}>
-                  {subject.counts.understood} understood / {subject.counts.in_progress} in progress
-                </span>
+                <span className={META_TEXT}>{subjectProgressSummary(subject)}</span>
               </button>
             );
           })}
@@ -273,15 +286,23 @@ export function OutcomeCoverageRow({
         {outcome.evidenceCount} evidence
       </div>
       <div className="flex items-center justify-between gap-3 lg:justify-end">
-        <div className={META_TEXT}>
-          {outcome.lastTouchedAt || "Not yet"}
-        </div>
-        <Link
-          href={outcome.viewHref}
-          className={`inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-2 ${CTA_TEXT} text-slate-900 transition hover:bg-slate-50`}
-        >
-          View
-        </Link>
+        <div className={META_TEXT}>{outcome.lastTouchedAt || "Getting started"}</div>
+        {outcome.canView && outcome.viewHref ? (
+          <Link
+            href={outcome.viewHref}
+            className={`inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-3 py-2 ${CTA_TEXT} text-slate-900 transition hover:bg-slate-50`}
+          >
+            View
+          </Link>
+        ) : (
+          <span
+            className={`inline-flex cursor-not-allowed items-center justify-center rounded-full border border-slate-200 bg-slate-100 px-3 py-2 ${CTA_TEXT} text-slate-500`}
+            title={outcome.viewUnavailableReason || "Add a capture to unlock this view."}
+            aria-disabled="true"
+          >
+            View
+          </span>
+        )}
       </div>
     </div>
   );
@@ -374,17 +395,17 @@ export function CurriculumMapEmptyState({
         *
       </div>
       <div className="grid gap-2">
-        <h2 className={SECTION_TITLE}>No curriculum signals yet for {learnerName}</h2>
+        <h2 className={SECTION_TITLE}>Start capturing learning moments to build curriculum coverage.</h2>
         <p className={`mx-auto max-w-[520px] ${BODY_TEXT}`}>
-          Tag a few learning blocks or captures to begin seeing coverage.
+          Add the first tagged moment for {learnerName} to start a calm, visible coverage trail.
         </p>
       </div>
       <div className="flex justify-center">
         <Link
-          href="/my-plan"
+          href="/capture"
           className={`inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 ${CTA_TEXT} text-white transition hover:bg-slate-800`}
         >
-          Open My Plan
+          Capture your first learning moment
         </Link>
       </div>
     </section>
@@ -433,4 +454,3 @@ export function CurriculumNextMoveCard({
     </section>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Make the Curriculum Map feel useful and encouraging when there is little or no data by softening zero-state language and surfacing a clear first action. 
- Avoid layout or data-model changes and keep changes limited to copy, CTAs, and safe UI behavior for outcome "View" controls.

### Description
- Replaced discouraging zero-state copy: `"Not yet"` → `"Getting started"`, `"0 understood / 0 in progress"` → `"No outcomes marked yet · Ready to begin"`, and the empty headline `"No curriculum signals yet for [learner]"` → `"Start capturing learning moments to build curriculum coverage."` in `app/components/curriculum/CurriculumMapOverviewComponents.tsx` and `app/components/FamilyCurriculumMapWorkspace.tsx`.
- Strengthened primary next-action CTAs to point to Capture for first-use flows by changing the empty-state CTA to link to `/capture` and update labels to `"Capture your first learning moment"` and adjusted the Next Move card accordingly.
- Prevented no-op `View` buttons by extending `OutcomeCoverageView` with `canView` and `viewUnavailableReason`, wiring `canView` when building `subjectViews`, and rendering either an active `Link` to evidence-filtered portfolio content or a disabled non-interactive `View` span with an explanatory `title` and `aria-disabled` when no evidence exists.

### Testing
- Ran `npm run lint -- app/components/FamilyCurriculumMapWorkspace.tsx app/components/curriculum/CurriculumMapOverviewComponents.tsx`, which failed due to environment dependency resolution for ESLint (missing package resolution referenced by `eslint.config.mjs`).
- No other automated tests were available in this environment; no unit or UI test runs were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4615ea688328a6ee95a0b4c0ed2f)