### PR TITLE
Improve My Portfolio empty-state tone

### DIFF
--- a/app/components/portfolio/PortfolioOverviewComponents.tsx
+++ b/app/components/portfolio/PortfolioOverviewComponents.tsx
@@ -164,9 +164,9 @@ export function PortfolioEmptyState({
         *
       </div>
       <div className="grid gap-2">
-        <h2 className={SECTION_TITLE}>No evidence yet for {learnerName}</h2>
+        <h2 className={SECTION_TITLE}>Start capturing learning moments to build {learnerName}&rsquo;s portfolio.</h2>
         <p className={`mx-auto max-w-[460px] ${BODY_TEXT}`}>
-          Capture your first learning moment to begin building the story.
+          This is where your learning story will grow over time.
         </p>
       </div>
       <div className="flex justify-center">


### PR DESCRIPTION
### Motivation
- Make the My Portfolio empty state more encouraging and forward-looking by replacing the terse “No evidence yet for …” copy with warmer, action-oriented language.

### Description
- Update `PortfolioEmptyState` in `app/components/portfolio/PortfolioOverviewComponents.tsx` by changing the headline to `Start capturing learning moments to build {learner}’s portfolio.` and the supporting line to `This is where your learning story will grow over time.`, with no layout or logic changes.

### Testing
- Ran `npm run -s lint app/components/portfolio/PortfolioOverviewComponents.tsx`, which failed in this environment because the `eslint` package is not installed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef47bcec548328b751a0fd47d9b8e6)