### PR TITLE
Refine early-state My Progress messaging tone

### DIFF
--- a/app/components/FamilyProgressWorkspace.tsx
+++ b/app/components/FamilyProgressWorkspace.tsx
@@ -127,21 +127,21 @@ function readinessLabel(percent: number) {
   if (percent >= 70) return "On track";
   if (percent >= 52) return "Building confidence";
   if (percent >= 30) return "Growing steadily";
-  return "Just beginning";
+  return "Starting to build";
 }
 
 function coverageLabel(count: number) {
   if (count >= 5) return "Healthy spread";
   if (count >= 3) return "Growing";
   if (count >= 1) return "Emerging";
-  return "Just starting";
+  return "Coverage will grow here";
 }
 
 function momentumLabel(recentCount: number) {
   if (recentCount >= 4) return "Building steadily";
   if (recentCount >= 2) return "Moving";
   if (recentCount >= 1) return "Starting to build";
-  return "Waiting for fresh evidence";
+  return "Ready for new evidence";
 }
 
 function deriveAreas(
@@ -494,7 +494,7 @@ export default function FamilyProgressWorkspace() {
                   ? "Reflections visible"
                   : evidenceCount >= 4
                     ? "Ready to reflect"
-                    : "Still forming"
+                    : "Reflection is building"
             }
             note={
               progressState === "live"

--- a/app/components/progress/ProgressOverviewComponents.tsx
+++ b/app/components/progress/ProgressOverviewComponents.tsx
@@ -220,7 +220,7 @@ export function ProgressTrendCard({
         </div>
       ) : (
         <div className="mt-5 rounded-[18px] border border-dashed border-slate-200 bg-white/80 px-4 py-5">
-          <div className={CARD_TITLE}>No progress signals yet</div>
+          <div className={CARD_TITLE}>Capture a few moments to start seeing progress</div>
           <div className={`mt-2 ${BODY_TEXT}`}>
             Capture a few learning moments to begin seeing the picture.
           </div>


### PR DESCRIPTION
### Motivation
- Improve early-state copy so the My Progress surface feels encouraging and forward-moving when data is minimal.
- Preserve existing meaning, branching, and UI structure while adjusting phrasing to be calm and supportive.

### Description
- Replace several early-state labels in `app/components/FamilyProgressWorkspace.tsx` to more encouraging phrasing: `"Just beginning"` → `"Starting to build"`, `"Just starting"` → `"Coverage will grow here"`, `"Waiting for fresh evidence"` → `"Ready for new evidence"`, and `"Still forming"` → `"Reflection is building"`.
- Update the empty-state headline in `app/components/progress/ProgressOverviewComponents.tsx` from `"No progress signals yet"` to `"Capture a few moments to start seeing progress"`.
- No logic, layout, or feature changes were made; this PR only updates user-facing copy.

### Testing
- Ran `npm run -s lint`, which failed in this environment due to a missing `eslint` package dependency.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4a8255d48328baafe8017351e9fd)