### PR TITLE
Improve Community "Start a conversation" error handling and validation

### DIFF
--- a/app/(auth)/community/[categorySlug]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/page.tsx
@@ -175,6 +175,24 @@ export default function CommunityCategoryPage() {
   const isFeatureCategory = isFeatureSuggestionCategory(resolvedCategory);
   const canStartDiscussion = Boolean(viewerId);
 
+  function getCreateThreadMessage(error: unknown) {
+    const message = String((error as { message?: unknown } | null)?.message ?? "").toLowerCase();
+
+    if (message.includes("sign in")) {
+      return "Sign in to start a conversation.";
+    }
+
+    if (message.includes("category could not be found")) {
+      return "This category could not be found. Go back to Community and choose a category again.";
+    }
+
+    if (message.includes("title and message")) {
+      return "Add a title and message to start the conversation.";
+    }
+
+    return "We could not post this conversation yet. Check that you are signed in and try again.";
+  }
+
   async function handleCreateThread() {
     if (!threadTitle.trim() || !threadBody.trim()) {
       setMessage("Add a title and message to start the conversation.");
@@ -182,7 +200,7 @@ export default function CommunityCategoryPage() {
     }
 
     if (!viewerId) {
-      setMessage("Sign in to start a conversation");
+      setMessage("Sign in to start a conversation.");
       return;
     }
 
@@ -201,7 +219,7 @@ export default function CommunityCategoryPage() {
       router.push(buildCommunityThreadHref(resolvedCategory.slug, result.thread.id));
     } catch (error) {
       console.error("Create thread failed", error);
-      setMessage("That discussion could not be posted right now.");
+      setMessage(getCreateThreadMessage(error));
     } finally {
       setSavingThread(false);
     }
@@ -348,7 +366,7 @@ export default function CommunityCategoryPage() {
               <button
                 type="button"
                 onClick={() => void handleCreateThread()}
-                disabled={savingThread}
+                disabled={savingThread || !viewerId}
                 style={{
                   border: "1px solid #2563eb",
                   background: "#2563eb",
@@ -357,8 +375,8 @@ export default function CommunityCategoryPage() {
                   padding: "10px 14px",
                   fontSize: 14,
                   fontWeight: 800,
-                  cursor: savingThread ? "wait" : "pointer",
-                  opacity: savingThread ? 0.8 : 1,
+                  cursor: savingThread ? "wait" : !viewerId ? "not-allowed" : "pointer",
+                  opacity: savingThread || !viewerId ? 0.8 : 1,
                 }}
               >
                 {savingThread ? "Starting..." : "Start conversation"}

--- a/lib/communityForum.ts
+++ b/lib/communityForum.ts
@@ -565,12 +565,45 @@ export async function createForumThread(input: {
     throw new Error("Sign in to start a conversation.");
   }
 
+  const title = safe(input.title);
+  const body = safe(input.body);
+
+  if (!title || !body) {
+    throw new Error("Add a title and message to start the conversation.");
+  }
+
+  const categoryId = safe(input.category.id);
+  const categorySlug = safe(input.category.slug);
+  const hasCategoryContext = Boolean(categoryId && categorySlug);
+
+  if (!hasCategoryContext) {
+    throw new Error("This category could not be found.");
+  }
+
+  const categoryLookupResp = await supabase
+    .from("community_categories")
+    .select("id,slug")
+    .eq("id", categoryId)
+    .eq("slug", categorySlug)
+    .maybeSingle();
+
+  if (categoryLookupResp.error) {
+    if (!isMissingRelationOrColumn(categoryLookupResp.error)) {
+      console.error("Community thread category lookup failed", categoryLookupResp.error);
+    }
+    throw categoryLookupResp.error;
+  }
+
+  if (!categoryLookupResp.data) {
+    throw new Error("This category could not be found.");
+  }
+
   const payload = {
-    category_id: input.category.id,
+    category_id: categoryId,
     user_id: input.viewerId,
-    title: safe(input.title),
-    body: safe(input.body),
-    excerpt: plainTextSnippet(input.body),
+    title,
+    body,
+    excerpt: plainTextSnippet(body),
     is_pinned: false,
     status: null,
   };


### PR DESCRIPTION
### Motivation
- The inline composer showed a vague "That discussion could not be posted right now." error that hid whether the failure was auth, validation, or category-resolution related.
- The page could attempt inserts with fallback/non-persisted category context which can fail silently at insert time.
- Fixes are needed to truthfully gate unauthenticated users and provide calm, actionable UI messages while preserving real DB writes and navigation on success.

### Description
- Hardened `createForumThread` in `lib/communityForum.ts` to validate `viewerId`, non-empty `title`/`body`, and to verify the category exists via a `community_categories` lookup by `id` + `slug` before performing the insert, and improved logging on lookup errors.
- Updated `app/(auth)/community/[categorySlug]/page.tsx` to map thrown errors to user-facing messages via `getCreateThreadMessage`, replacing the single generic failure string with specific guidance for sign-in, missing title/body, or missing category, and a calm generic fallback.
- Disabled the inline composer submit button for unauthenticated viewers (`disabled={savingThread || !viewerId}`) and adjusted cursor/opacity so the UI truthfully reflects gated state.
- Preserved existing successful flow: real DB insert followed by `router.push(buildCommunityThreadHref(...))` and retained best-effort activity upsert logic.

### Testing
- Attempted build with `npm run build`, but the build could not complete in this environment because the `next` binary was not available (`next: not found`), so a full build verification could not run here.
- Package installation (`npm install`) was started in the environment but could not be completed within the session, so runtime integration checks (full build) were not possible; unit/automated tests were not executed as `next`/dependencies were missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef500cb90c8328886f220459b58dde)