### PR TITLE
Fix community start conversation write path failures

### DIFF
--- a/app/(auth)/community/[categorySlug]/page.tsx
+++ b/app/(auth)/community/[categorySlug]/page.tsx
@@ -182,7 +182,7 @@ export default function CommunityCategoryPage() {
     }
 
     if (!viewerId) {
-      setMessage("Sign in to start a conversation");
+      setMessage("Sign in to start a conversation.");
       return;
     }
 
@@ -201,7 +201,11 @@ export default function CommunityCategoryPage() {
       router.push(buildCommunityThreadHref(resolvedCategory.slug, result.thread.id));
     } catch (error) {
       console.error("Create thread failed", error);
-      setMessage("That discussion could not be posted right now.");
+      const nextMessage =
+        error instanceof Error && error.message
+          ? error.message
+          : "Something didn’t go through. Try again in a moment.";
+      setMessage(nextMessage);
     } finally {
       setSavingThread(false);
     }

--- a/app/(auth)/community/new/page.tsx
+++ b/app/(auth)/community/new/page.tsx
@@ -91,7 +91,7 @@ export default function CommunityComposePage() {
 
         if (!userId) {
           setCategories(FALLBACK_OPTIONS);
-          setMessage("Sign in to start a conversation");
+          setMessage("Sign in to start a conversation.");
           return;
         }
 
@@ -148,7 +148,7 @@ export default function CommunityComposePage() {
 
   async function handleSubmit() {
     if (!viewerId) {
-      setMessage("Sign in to start a conversation");
+      setMessage("Sign in to start a conversation.");
       return;
     }
 
@@ -184,7 +184,11 @@ export default function CommunityComposePage() {
       router.push(buildCommunityThreadHref(selectedCategory.slug, result.thread.id));
     } catch (error) {
       console.error("Create thread failed", error);
-      setMessage("That discussion could not be posted right now.");
+      const nextMessage =
+        error instanceof Error && error.message
+          ? error.message
+          : "Something didn’t go through. Try again in a moment.";
+      setMessage(nextMessage);
     } finally {
       setSaving(false);
     }

--- a/lib/communityForum.ts
+++ b/lib/communityForum.ts
@@ -561,15 +561,51 @@ export async function createForumThread(input: {
   title: string;
   body: string;
 }) {
-  if (!safe(input.viewerId)) {
+  const authViewerId = await requireCommunityUserId();
+  if (!authViewerId) {
     throw new Error("Sign in to start a conversation.");
   }
 
+  const title = safe(input.title);
+  const body = safe(input.body);
+  if (!title || !body) {
+    throw new Error("Add a title and message to start the conversation.");
+  }
+
+  const categorySlug = safe(input.category.slug);
+  if (!categorySlug) {
+    throw new Error("This category could not be found. Go back and try again.");
+  }
+
+  let resolvedCategoryId = safe(input.category.id);
+  try {
+    const categoryResp = await supabase
+      .from("community_categories")
+      .select("id")
+      .eq("slug", categorySlug)
+      .maybeSingle();
+
+    if (categoryResp.error) throw categoryResp.error;
+    resolvedCategoryId = safe((categoryResp.data as { id?: unknown } | null)?.id);
+  } catch (error: any) {
+    if (isMissingRelationOrColumn(error)) {
+      throw error;
+    }
+    if (error?.code === "42501") {
+      throw new Error("Sign in to start a conversation.");
+    }
+    throw new Error("This category could not be found. Go back and try again.");
+  }
+
+  if (!resolvedCategoryId) {
+    throw new Error("This category could not be found. Go back and try again.");
+  }
+
   const payload = {
-    category_id: input.category.id,
-    user_id: input.viewerId,
-    title: safe(input.title),
-    body: safe(input.body),
+    category_id: resolvedCategoryId,
+    user_id: authViewerId,
+    title,
+    body,
     excerpt: plainTextSnippet(input.body),
     is_pinned: false,
     status: null,
@@ -604,6 +640,13 @@ export async function createForumThread(input: {
 
     return { thread, source: "database" as const };
   } catch (error) {
+    const errorCode = String((error as { code?: unknown })?.code ?? "");
+    if (errorCode === "42501") {
+      throw new Error("Sign in to start a conversation.");
+    }
+    if (errorCode === "23503") {
+      throw new Error("This category could not be found. Go back and try again.");
+    }
     if (!isMissingRelationOrColumn(error)) {
       console.error("Community thread create failed", error);
     }


### PR DESCRIPTION
### Motivation
- Users attempting to "Start conversation" were getting a generic write failure because the server-side insert was using client-provided/fallback category IDs and unverified user IDs, which violated DB constraints and RLS checks.

### Description
- Validate authentication at write time by calling `requireCommunityUserId()` inside `createForumThread` and use that verified `user_id` for inserts. 
- Validate `title` and `body` server-side and return an actionable error when missing. 
- Resolve the category by `slug` from `community_categories` before inserting and use the real `id` in the `community_threads` payload instead of trusting client fallback IDs. 
- Map common DB/RLS errors to clear messages (auth-related `42501` → sign-in message, FK-related `23503` → missing category message) and rethrow others. 
- Surface server error messages in the two compose entry points (`app/(auth)/community/new/page.tsx` and `app/(auth)/community/[categorySlug]/page.tsx`) instead of the generic failure text, and tighten sign-in prompt wording.

Files changed: `lib/communityForum.ts`, `app/(auth)/community/new/page.tsx`, `app/(auth)/community/[categorySlug]/page.tsx`.

### Testing
- Tried `npm.cmd run build` which failed in this environment because `npm.cmd` is not present. 
- Ran `npm run build` which attempted to run `next build` but failed because the `next` binary is not available in the container environment (build could not be executed here).
- No automated unit tests were executed in this environment due to missing Next.js runtime; behavior should be verified in a proper dev or CI environment where `next` is available by running `npm run build` and exercising the three verification flows (signed-in success + redirect, signed-out blocked, invalid category error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef53ffdd288328bc7d908d3b6c22c0)