### PR TITLE
Require Supabase env and add session guard for Community thread inserts

### DIFF
--- a/lib/communityForum.ts
+++ b/lib/communityForum.ts
@@ -617,6 +617,24 @@ export async function requireCommunityUserId(): Promise<string | null> {
   return response.data.user?.id || null;
 }
 
+async function requireCommunityAuthenticatedSession(expectedUserId: string) {
+  const [sessionResponse, userResponse] = await Promise.all([
+    supabase.auth.getSession(),
+    supabase.auth.getUser(),
+  ]);
+
+  const session = sessionResponse.data.session;
+  const user = userResponse.data.user;
+
+  if (!session?.access_token || !user?.id) {
+    throw new Error("Your sign-in session is missing. Sign out and sign in again before posting.");
+  }
+
+  if (user.id !== expectedUserId) {
+    throw new Error("Your current sign-in changed. Refresh Community and try posting again.");
+  }
+}
+
 export async function loadCommunityHomeData(viewerId: string) {
   if (!text(viewerId)) {
     throw new Error("Sign in to browse Community.");
@@ -750,6 +768,8 @@ export async function createForumThread(input: {
   if (!body) {
     throw new Error("Add an opening post.");
   }
+
+  await requireCommunityAuthenticatedSession(viewerId);
 
   const category = await loadCategoryById(categoryId);
   if (!category) {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,23 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 
-const bundledPublicSupabaseUrl = "https://jgllsqixpfypunnstinl.supabase.co";
-const bundledPublicSupabaseAnonKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpnbGxzcWl4cGZ5cHVubnN0aW5sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY5MTc0MDYsImV4cCI6MjA4MjQ5MzQwNn0.YYKiRuxYye7_iDfQ4nZ6U4pFiTVtt1lIGSSwQa98CBE";
-
-const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL || bundledPublicSupabaseUrl;
-const supabaseAnonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || bundledPublicSupabaseAnonKey;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
 export const hasSupabaseEnv = Boolean(supabaseUrl && supabaseAnonKey);
 const SUPABASE_REQUEST_TIMEOUT_MS = 20000;
 
-if (
-  !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-) {
-  console.warn(
-    "Supabase public environment variables are missing. Using bundled public project auth configuration as a fallback.",
+if (!hasSupabaseEnv) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY. Configure explicit Supabase environment values to avoid writing to the wrong project.",
   );
 }
 
@@ -43,8 +34,8 @@ async function supabaseFetch(input: RequestInfo | URL, init?: RequestInit) {
 }
 
 export const supabase = createClient(
-  supabaseUrl,
-  supabaseAnonKey,
+  supabaseUrl as string,
+  supabaseAnonKey as string,
   {
     auth: {
       persistSession: true,
@@ -58,7 +49,7 @@ export const supabase = createClient(
 );
 
 export function createServerSupabaseClient(accessToken: string) {
-  return createClient(supabaseUrl, supabaseAnonKey, {
+  return createClient(supabaseUrl as string, supabaseAnonKey as string, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,


### PR DESCRIPTION
### Motivation
- A persistent RLS `42501` on `community_threads` indicated writes were being blocked despite correct DB policies, most likely because the app either targeted the wrong Supabase project (silent bundled fallback keys) or sent unauthenticated requests while showing a `viewerId` in the UI.
- The goal is to fail fast and surface misconfiguration or a missing/stale auth session rather than continually changing table policies.

### Description
- Removed the bundled public Supabase URL/anon key fallback and now require explicit `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`, throwing a clear error if they are missing (`lib/supabaseClient.ts`).
- Added `requireCommunityAuthenticatedSession(expectedUserId)` and call it from `createForumThread` to verify `supabase.auth.getSession()` and `supabase.auth.getUser()` return a valid `access_token` and that the signed-in user's id matches the `viewerId` being written (`lib/communityForum.ts`).
- Kept the insert payload unchanged (it still writes `category_id`, `user_id`, `title`, `body`, `excerpt`, `is_pinned`, `status`) and left RLS policy shape (auth.uid() = user_id) intact because that is the correct security model.

### Testing
- Attempted a local build with `npm run build`, but it failed in this environment with `sh: 1: next: not found`, so the production build could not be completed here.
- No automated DB migrations/tests were run in this environment; the change is limited to client-side runtime checks and will surface missing env/session issues immediately when run in a deployed or properly-configured local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1bffb94088328bd07c8d72a7e050d)