### PR TITLE
Add Supabase project ref helper for env alignment diagnostics

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -21,6 +21,15 @@ if (
   );
 }
 
+function extractSupabaseProjectRef(url: string) {
+  const match = url.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co/i);
+  return match?.[1] ?? null;
+}
+
+export function getSupabaseProjectRef() {
+  return extractSupabaseProjectRef(supabaseUrl);
+}
+
 async function supabaseFetch(input: RequestInfo | URL, init?: RequestInit) {
   let timer: ReturnType<typeof setTimeout> | null = null;
 


### PR DESCRIPTION
### Motivation
- Community thread inserts produce RLS errors and a silent bundled Supabase fallback can cause the app to talk to the wrong project, so a non-secret runtime helper is needed to verify the effective Supabase project ref without exposing keys.

### Description
- Added `extractSupabaseProjectRef()` and exported `getSupabaseProjectRef()` in `lib/supabaseClient.ts` to derive the `<ref>` from the configured `supabaseUrl` (no secrets exposed) and left existing client behavior unchanged.

### Testing
- Attempted `npm run build` in this environment and it failed because `next` is not available in the container PATH (`sh: 1: next: not found`), no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d0f585308328bbe3ccd74b8bf658)