### PR TITLE
Harden Supabase env config and add community auth diagnostics

### DIFF
--- a/lib/communityForum.ts
+++ b/lib/communityForum.ts
@@ -1,4 +1,4 @@
-import { supabase } from "@/lib/supabaseClient";
+import { supabase, supabaseProjectRef } from "@/lib/supabaseClient";
 
 export type ForumThreadStatus = "under_review" | "planned" | "released" | null;
 
@@ -613,8 +613,23 @@ export function buildCommunityThreadHref(categorySlug: string, threadId: string)
 }
 
 export async function requireCommunityUserId(): Promise<string | null> {
-  const response = await supabase.auth.getUser();
-  return response.data.user?.id || null;
+  const [userResponse, sessionResponse] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase.auth.getSession(),
+  ]);
+
+  const userId = userResponse.data.user?.id || null;
+  const hasAccessToken = Boolean(sessionResponse.data.session?.access_token);
+
+  if (typeof window !== "undefined") {
+    console.info("[CommunityAuthDiag]", {
+      supabaseProjectRef,
+      hasAccessToken,
+      userId,
+    });
+  }
+
+  return userId;
 }
 
 export async function loadCommunityHomeData(viewerId: string) {

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,25 +1,23 @@
 import { createClient } from "@supabase/supabase-js";
 
-const bundledPublicSupabaseUrl = "https://jgllsqixpfypunnstinl.supabase.co";
-const bundledPublicSupabaseAnonKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpnbGxzcWl4cGZ5cHVubnN0aW5sIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY5MTc0MDYsImV4cCI6MjA4MjQ5MzQwNn0.YYKiRuxYye7_iDfQ4nZ6U4pFiTVtt1lIGSSwQa98CBE";
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL || bundledPublicSupabaseUrl;
-const supabaseAnonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || bundledPublicSupabaseAnonKey;
-
-export const hasSupabaseEnv = Boolean(supabaseUrl && supabaseAnonKey);
-const SUPABASE_REQUEST_TIMEOUT_MS = 20000;
-
-if (
-  !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-) {
-  console.warn(
-    "Supabase public environment variables are missing. Using bundled public project auth configuration as a fallback.",
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY. Set both environment variables for the active deployment environment.",
   );
 }
+
+export const hasSupabaseEnv = true;
+const SUPABASE_REQUEST_TIMEOUT_MS = 20000;
+
+export function getSupabaseProjectRef(url: string) {
+  const match = url.match(/^https:\/\/([a-z0-9-]+)\.supabase\.co$/i);
+  return match?.[1] || "unknown";
+}
+
+export const supabaseProjectRef = getSupabaseProjectRef(supabaseUrl);
 
 async function supabaseFetch(input: RequestInfo | URL, init?: RequestInit) {
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -42,20 +40,16 @@ async function supabaseFetch(input: RequestInfo | URL, init?: RequestInit) {
   }
 }
 
-export const supabase = createClient(
-  supabaseUrl,
-  supabaseAnonKey,
-  {
-    auth: {
-      persistSession: true,
-      autoRefreshToken: true,
-      detectSessionInUrl: true,
-    },
-    global: {
-      fetch: supabaseFetch,
-    },
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
   },
-);
+  global: {
+    fetch: supabaseFetch,
+  },
+});
 
 export function createServerSupabaseClient(accessToken: string) {
   return createClient(supabaseUrl, supabaseAnonKey, {


### PR DESCRIPTION
### Motivation
- Prevent silent use of a bundled public Supabase project when deployment env vars are missing so the app cannot accidentally talk to the wrong project.
- Provide lightweight runtime diagnostics to prove whether the browser has a real Supabase user session when Community writes are attempted.
- Focus on environment and auth verification rather than changing schema or RLS policies.

### Description
- Update `lib/supabaseClient.ts` to remove the bundled fallback keys and to fail fast when `NEXT_PUBLIC_SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_ANON_KEY` are missing.
- Add `getSupabaseProjectRef()` and export `supabaseProjectRef` to derive and expose the Supabase project ref for alignment checks.
- Keep normal browser auth options (`persistSession`, `autoRefreshToken`, `detectSessionInUrl`) and a custom `supabaseFetch` timeout wrapper.
- Update `requireCommunityUserId()` in `lib/communityForum.ts` to fetch both `getUser()` and `getSession()` and to log a compact diagnostic (`supabaseProjectRef`, `hasAccessToken`, `userId`) to the browser console without printing any secrets.

### Testing
- Attempted `npm run build`; the build step reached `next build` but failed in this container with `sh: 1: next: not found`, so a full production build could not be completed here.
- Code changes were staged and committed as part of validation (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2a4ec79148328b6de54fc922860c8)